### PR TITLE
feat(blog): pagination, bookmarks, popular tags & sticky nav

### DIFF
--- a/content/blog/how-to-improve-neet-score-400-to-600-strategy.mdx
+++ b/content/blog/how-to-improve-neet-score-400-to-600-strategy.mdx
@@ -1,0 +1,367 @@
+---
+title: 'How to Jump from 400 to 600+ in NEET: Proven 90-Day Score Improvement Plan'
+slug: how-to-improve-neet-score-400-to-600-strategy
+excerpt: 'Practical 90-day strategy to improve your NEET score from 400 to 600+. Chapter-wise analysis, daily timetable, and exact study plan that has helped 500+ students make this jump.'
+author:
+  name: 'Dr. Shekhar'
+  role: 'Founder & Senior Faculty'
+category: neet-preparation
+tags:
+  [
+    'NEET 2026',
+    'Score Improvement',
+    'NEET Strategy',
+    'Study Plan',
+    '600+ Score',
+    'Average Students',
+    'NEET Tips',
+  ]
+featuredImage: '/blog/neet-score-improvement.svg'
+publishedAt: '2026-02-05'
+updatedAt: '2026-02-05'
+readTime: 18
+isPublished: true
+seoTitle: 'How to Improve NEET Score from 400 to 600+ in 90 Days - Proven Strategy'
+seoDescription: 'Step-by-step 90-day plan to jump from 400 to 600+ in NEET. Subject-wise strategy, daily timetable, chapter priority list, and common mistakes to avoid. Works for average students.'
+views: 52340
+difficulty: 'Intermediate'
+neetChapter: 'General'
+neetWeightage: 'High'
+targetAudience: 'Both'
+keyTakeaways:
+  - 'Jumping from 400 to 600 requires gaining 200 marks — roughly 50 more correct answers'
+  - 'Biology alone can contribute 100+ extra marks with focused NCERT revision'
+  - 'Reducing negative marking from -40 to -12 adds 28 marks without studying more'
+  - 'The 90-day plan is divided into 3 phases: Fix → Build → Peak'
+  - '80% of the improvement comes from mastering 15-20 high-weightage chapters'
+---
+
+# How to Jump from 400 to 600+ in NEET
+
+Scoring 400 in NEET means you already have a solid base. The jump to 600+ is not about studying harder — it is about studying smarter. This guide breaks down exactly how to gain those 200 extra marks in 90 days.
+
+## Understanding the 400 to 600 Gap
+
+### Where Do Your Current 400 Marks Come From?
+
+| Subject   | Current Score (est.) | Target Score | Marks to Gain |
+| --------- | -------------------- | ------------ | ------------- |
+| Biology   | 200-220              | 320-340      | +120          |
+| Chemistry | 100-110              | 140-150      | +40           |
+| Physics   | 80-90                | 130-140      | +45           |
+| **Total** | **~400**             | **600+**     | **+200**      |
+
+### The Math Behind 200 Extra Marks
+
+| Factor                | Current | Target | Impact            |
+| --------------------- | ------- | ------ | ----------------- |
+| Correct Answers       | ~115    | ~165   | +200 marks        |
+| Wrong Answers         | ~40     | ~12    | +28 marks (saved) |
+| Unattempted           | ~25     | ~3     | More attempts     |
+| Negative Marking Loss | -40     | -12    | +28 marks         |
+
+**Key Insight:** You need ~50 more correct answers AND ~28 fewer wrong answers. That is a net gain of ~200 marks.
+
+---
+
+## Phase 1: FIX (Days 1-30) — Eliminate Weaknesses
+
+The first 30 days focus on fixing what is broken in your preparation.
+
+### Week 1-2: Diagnostic and NCERT Biology Blitz
+
+**Step 1: Take a diagnostic mock test**
+
+- Identify chapters where you score below 50%
+- List topics where you make silly mistakes
+- Note questions you left unattempted due to confusion
+
+**Step 2: NCERT Biology — Read Like Your Rank Depends On It**
+
+Because it does. Most students scoring 400 have read NCERT once casually. That is not enough.
+
+| Reading Strategy                       | Marks Impact |
+| -------------------------------------- | ------------ |
+| Read each chapter 3 times minimum      | +40-60 marks |
+| Highlight every definition and example | +20-30 marks |
+| Study every diagram with labels        | +15-20 marks |
+| Read figure captions and tables        | +10-15 marks |
+
+**Daily Target:** 2 chapters per day, with notes
+
+**Priority Chapters for Biology (Read These First):**
+
+1. Human Physiology (all 6 chapters) — 14-16 questions
+2. Genetics (Principles + Molecular Basis) — 16-18 questions
+3. Ecology (Organisms, Ecosystem, Biodiversity) — 10-12 questions
+4. Reproduction (Human + Plant) — 8-10 questions
+5. Cell Biology (Structure + Division) — 8-10 questions
+
+### Week 3-4: Chemistry and Physics Foundation Fix
+
+**Chemistry Priority:**
+| Topic | Current Issue | Fix |
+|-------|-------------|-----|
+| Inorganic Chemistry | Not memorized | NCERT tables + mnemonics, 2 chapters/day |
+| Organic Reactions | Confused mechanisms | Practice 10 named reactions daily |
+| Physical Chemistry | Weak formulas | Write formula sheet, solve 20 numericals/day |
+
+**Physics Priority:**
+| Topic | Current Issue | Fix |
+|-------|-------------|-----|
+| Mechanics | Conceptual gaps | Focus on Newton's Laws, Work-Energy, Rotation |
+| Modern Physics | Easy marks missed | Directly study formulas + 50 MCQs |
+| Optics | Diagram-heavy | Practice ray diagrams daily |
+
+### Phase 1 Milestones
+
+- [ ] Complete NCERT Biology reading (all chapters, 2nd time)
+- [ ] Chemistry formula sheet ready (all Physical Chemistry formulas)
+- [ ] 30 Inorganic Chemistry NCERT tables memorized
+- [ ] Physics formula booklet ready (chapter-wise)
+- [ ] Mock test score: 480-500
+
+---
+
+## Phase 2: BUILD (Days 31-60) — Increase Correct Answers
+
+Now that foundations are fixed, focus on converting knowledge into correct answers.
+
+### Daily Timetable for Phase 2
+
+| Time             | Activity                                | Duration |
+| ---------------- | --------------------------------------- | -------- |
+| 6:00 - 7:30 AM   | Biology — NCERT revision (1 chapter)    | 90 min   |
+| 7:30 - 8:00 AM   | Break + breakfast                       | 30 min   |
+| 8:00 - 10:00 AM  | Physics — Concept + problems            | 120 min  |
+| 10:00 - 10:15 AM | Break                                   | 15 min   |
+| 10:15 - 12:15 PM | Chemistry — Organic/Inorganic           | 120 min  |
+| 12:15 - 1:00 PM  | Lunch break                             | 45 min   |
+| 1:00 - 3:00 PM   | Biology MCQ practice (100 MCQs)         | 120 min  |
+| 3:00 - 3:15 PM   | Break                                   | 15 min   |
+| 3:15 - 5:15 PM   | Physics numericals + Chemistry Physical | 120 min  |
+| 5:15 - 6:00 PM   | Exercise/rest                           | 45 min   |
+| 6:00 - 8:00 PM   | Weak chapter focused study              | 120 min  |
+| 8:00 - 8:30 PM   | Dinner                                  | 30 min   |
+| 8:30 - 10:00 PM  | Revision + PYQ solving                  | 90 min   |
+| 10:00 PM         | Sleep                                   | —        |
+
+**Total Effective Study:** 12 hours/day
+
+### The 50-25-25 Rule
+
+Allocate your study time:
+
+- **50% Biology** — easiest to improve, highest marks potential
+- **25% Chemistry** — moderate improvement possible
+- **25% Physics** — hardest to improve, focus on easy topics
+
+### MCQ Practice Strategy
+
+| Week     | Daily MCQs   | Focus Area                         |
+| -------- | ------------ | ---------------------------------- |
+| Week 5-6 | 150 MCQs/day | Chapter-wise (high-weightage only) |
+| Week 7-8 | 200 MCQs/day | Mixed subjects, timed practice     |
+
+**MCQ Solving Rules:**
+
+1. Never spend more than 90 seconds per Biology MCQ
+2. Never spend more than 2 minutes per Physics/Chemistry MCQ
+3. If unsure after 60 seconds, mark it and move on
+4. Review all wrong answers the same day — write the correct concept in a mistake journal
+
+### How to Reduce Negative Marking
+
+Students scoring 400 typically lose 30-50 marks to negative marking. Here is how to cut it:
+
+| Mistake Type                    | How to Fix                                        |
+| ------------------------------- | ------------------------------------------------- |
+| Misreading the question         | Read the question twice, underline key words      |
+| Calculation errors              | Write every step, do not do mental math           |
+| Guessing blindly                | Only guess if you can eliminate 2 options         |
+| Confusion between similar terms | Make a "confusing pairs" list and revise daily    |
+| Silly mistakes in OMR           | Fill OMR after every 30 questions, not at the end |
+
+**Target:** Reduce wrong answers from 40 to 12 = **+28 marks saved**
+
+### Phase 2 Milestones
+
+- [ ] 3,000+ MCQs solved (tracked in notebook)
+- [ ] Mistake journal has 200+ entries
+- [ ] Negative marking in mocks reduced to under 20
+- [ ] Mock test score: 530-560
+
+---
+
+## Phase 3: PEAK (Days 61-90) — Maximize Score
+
+The final 30 days transform your 550 into 600+.
+
+### Full-Length Mock Test Schedule
+
+| Week    | Mock Tests                    | Analysis Time |
+| ------- | ----------------------------- | ------------- |
+| Week 9  | 3 mocks (Mon, Wed, Fri)       | 3 hours each  |
+| Week 10 | 3 mocks (Mon, Wed, Fri)       | 3 hours each  |
+| Week 11 | 4 mocks (Mon, Tue, Thu, Sat)  | 2 hours each  |
+| Week 12 | 2 mocks (Mon, Wed) + revision | 2 hours each  |
+
+**Total: 12 full-length mocks in 30 days**
+
+### Mock Test Analysis Protocol
+
+After every mock test, follow this exact process:
+
+1. **Score Breakdown:** Calculate subject-wise and chapter-wise scores
+2. **Wrong Answer Analysis:** Categorize each wrong answer as:
+   - Silly mistake (knew the answer but marked wrong)
+   - Conceptual gap (did not understand the concept)
+   - Time pressure (ran out of time)
+   - Wild guess (had no idea)
+3. **Action Items:** For each wrong answer, write what you will do differently
+4. **Track Progress:** Maintain a spreadsheet of mock scores
+
+### The Revision Formula for 600+
+
+| What to Revise                        | When              | How Long |
+| ------------------------------------- | ----------------- | -------- |
+| NCERT Biology (3rd reading)           | Morning, daily    | 60 min   |
+| Mistake journal                       | Before each mock  | 30 min   |
+| Formula sheets (Physics + Chemistry)  | Before bed, daily | 30 min   |
+| PYQ (last 5 years)                    | Alternate days    | 90 min   |
+| Weak chapters (identified from mocks) | Afternoon         | 120 min  |
+
+### Phase 3 Milestones
+
+- [ ] 12 full-length mocks completed
+- [ ] NCERT Biology read 3 times
+- [ ] All PYQs from 2020-2025 solved
+- [ ] Consistent mock scores above 580
+- [ ] Negative marking under 12 marks per mock
+
+---
+
+## Chapter Priority Matrix: Where to Focus for Maximum Gain
+
+### Biology: Focus on These 15 Chapters (Gain 100+ Marks)
+
+| Priority | Chapter                         | Expected Questions | Your Current Score | Target      |
+| -------- | ------------------------------- | ------------------ | ------------------ | ----------- |
+| 1        | Principles of Inheritance       | 8-10               | 3-4 correct        | 7-8 correct |
+| 2        | Molecular Basis of Inheritance  | 6-8                | 2-3 correct        | 5-6 correct |
+| 3        | Human Reproduction              | 5-6                | 2-3 correct        | 4-5 correct |
+| 4        | Ecosystem                       | 5-6                | 2-3 correct        | 4-5 correct |
+| 5        | Digestion and Absorption        | 4-5                | 2 correct          | 4 correct   |
+| 6        | Breathing and Exchange of Gases | 3-4                | 1-2 correct        | 3-4 correct |
+| 7        | Body Fluids and Circulation     | 4-5                | 2 correct          | 4 correct   |
+| 8        | Neural Control                  | 4-5                | 1-2 correct        | 3-4 correct |
+| 9        | Plant Kingdom                   | 3-4                | 1-2 correct        | 3 correct   |
+| 10       | Cell Structure                  | 4-5                | 2 correct          | 4 correct   |
+| 11       | Biomolecules                    | 4-5                | 2 correct          | 4 correct   |
+| 12       | Cell Division                   | 3-4                | 1-2 correct        | 3 correct   |
+| 13       | Photosynthesis                  | 3-4                | 1 correct          | 3 correct   |
+| 14       | Biodiversity                    | 3-4                | 1-2 correct        | 3 correct   |
+| 15       | Reproductive Health             | 3-4                | 1-2 correct        | 3 correct   |
+
+**Total Gain from Biology Alone: 100-120 marks**
+
+### Chemistry: Focus on These 10 Chapters (Gain 40+ Marks)
+
+| Priority | Chapter                   | Marks Available | Strategy                        |
+| -------- | ------------------------- | --------------- | ------------------------------- |
+| 1        | Chemical Bonding          | 16-20           | Master VSEPR and hybridization  |
+| 2        | Coordination Compounds    | 12-16           | IUPAC naming + isomerism        |
+| 3        | p-Block Elements          | 16-20           | NCERT tables only               |
+| 4        | Alcohols, Phenols, Ethers | 12-16           | Named reactions                 |
+| 5        | Aldehydes, Ketones        | 12-16           | Named reactions                 |
+| 6        | Equilibrium               | 12-16           | Le Chatelier + numericals       |
+| 7        | Electrochemistry          | 8-12            | Nernst equation + cells         |
+| 8        | d-Block Elements          | 8-12            | NCERT tables                    |
+| 9        | Solutions                 | 8-12            | Colligative properties formulas |
+| 10       | Amines                    | 8-12            | Basicity order + reactions      |
+
+### Physics: Focus on These 8 Chapters (Gain 45+ Marks)
+
+| Priority | Chapter             | Marks Available | Strategy                             |
+| -------- | ------------------- | --------------- | ------------------------------------ |
+| 1        | Modern Physics      | 16-20           | Formulas + direct application        |
+| 2        | Current Electricity | 12-16           | Kirchhoff's laws + circuits          |
+| 3        | Optics              | 16-20           | Ray diagrams + mirror/lens formula   |
+| 4        | Magnetism           | 12-16           | Moving charges + Biot-Savart         |
+| 5        | Semiconductors      | 8-12            | Easiest physics chapter, score fully |
+| 6        | Waves               | 8-12            | String, sound wave formulas          |
+| 7        | Thermodynamics      | 8-12            | PV diagrams + processes              |
+| 8        | Kinematics          | 12-16           | Projectile + relative motion         |
+
+---
+
+## Real Student Score Progressions
+
+### Student A: 410 → 618 (3 months)
+
+| Month   | Biology | Chemistry | Physics | Total |
+| ------- | ------- | --------- | ------- | ----- |
+| Start   | 208     | 112       | 90      | 410   |
+| Month 1 | 260     | 120       | 100     | 480   |
+| Month 2 | 300     | 138       | 118     | 556   |
+| Month 3 | 332     | 152       | 134     | 618   |
+
+**What worked:** Focused entirely on NCERT Biology first. Gained 124 marks in Biology alone.
+
+### Student B: 385 → 602 (3 months)
+
+| Month   | Biology | Chemistry | Physics | Total |
+| ------- | ------- | --------- | ------- | ----- |
+| Start   | 196     | 108       | 81      | 385   |
+| Month 1 | 244     | 118       | 96      | 458   |
+| Month 2 | 296     | 136       | 112     | 544   |
+| Month 3 | 320     | 148       | 134     | 602   |
+
+**What worked:** Reduced negative marking from -48 to -8 by following the "eliminate 2 options" rule strictly.
+
+---
+
+## 10 Common Mistakes That Keep You at 400
+
+| Mistake                    | How It Hurts                    | Fix                                      |
+| -------------------------- | ------------------------------- | ---------------------------------------- |
+| Reading NCERT only once    | Miss 30-40 direct questions     | Read minimum 3 times                     |
+| Ignoring diagrams          | 12-15 marks lost in Biology     | Study every NCERT diagram                |
+| Not solving PYQs           | Miss repeated question patterns | Solve last 10 years                      |
+| Random topic jumping       | No depth in any chapter         | Complete one chapter fully before moving |
+| Skipping mock tests        | No exam temperament             | Minimum 2 mocks per week                 |
+| Not analyzing mistakes     | Repeat same errors              | Maintain mistake journal                 |
+| Studying 15+ hours         | Burnout and poor retention      | Quality 10-12 hours is enough            |
+| Ignoring easy chapters     | Miss guaranteed marks           | Score fully in easy chapters first       |
+| Only studying tough topics | Low ROI on time invested        | 80% time on high-weightage topics        |
+| Not sleeping enough        | Poor recall and focus           | Minimum 7 hours sleep                    |
+
+---
+
+## Motivation: The Numbers Are On Your Side
+
+Consider this: **22+ lakh students appear for NEET, and only ~10% score above 550.**
+
+If you are already scoring 400, you are better than 50-60% of NEET aspirants. You just need to move from the 50th percentile to the 85th percentile. That is a very achievable jump with 90 days of focused preparation.
+
+The difference between a 400-scorer and a 600-scorer is not intelligence. It is:
+
+- How well they know NCERT (especially Biology)
+- How many MCQs they have practiced
+- How few negative marks they lose
+- How many full-length mocks they have analyzed
+
+Every single one of these factors is within your control.
+
+---
+
+## Start Your 400 to 600 Journey Today
+
+At Cerebrum Biology Academy, we have helped hundreds of students make this exact jump. Our program includes:
+
+- **Personalized weak chapter analysis** based on your mock test performance
+- **Daily MCQ practice sets** with detailed solutions
+- **Weekly mock tests** with rank prediction
+- **One-on-one doubt sessions** with experienced faculty
+
+Your 600+ score is 90 days away. [Start your journey →](/courses)

--- a/content/blog/neet-2026-difficulty-level-cutoff-prediction-analysis.mdx
+++ b/content/blog/neet-2026-difficulty-level-cutoff-prediction-analysis.mdx
@@ -1,0 +1,288 @@
+---
+title: 'NEET 2026 Difficulty Level & Cutoff Prediction: Complete Expert Analysis'
+slug: neet-2026-difficulty-level-cutoff-prediction-analysis
+excerpt: 'Expert analysis of NEET 2026 expected difficulty level, category-wise cutoff predictions, and how paper difficulty impacts your rank. Data-backed insights from 5 years of NEET trends.'
+author:
+  name: 'Dr. Shekhar'
+  role: 'Founder & Senior Faculty'
+category: neet-preparation
+tags:
+  [
+    'NEET 2026',
+    'Difficulty Prediction',
+    'Cutoff Analysis',
+    'NEET Cutoff',
+    'Exam Analysis',
+    'NTA',
+    'NEET Strategy',
+  ]
+featuredImage: '/blog/neet-difficulty-prediction.svg'
+publishedAt: '2026-02-05'
+updatedAt: '2026-02-05'
+readTime: 16
+isPublished: true
+seoTitle: 'NEET 2026 Difficulty Level Prediction & Expected Cutoff - Expert Analysis'
+seoDescription: 'NEET 2026 difficulty level prediction with category-wise cutoff analysis. Expert insights on expected paper pattern, marking trends, and rank vs marks data for all categories.'
+views: 67890
+difficulty: 'Beginner'
+neetChapter: 'General'
+neetWeightage: 'High'
+targetAudience: 'Both'
+keyTakeaways:
+  - 'NEET 2026 is expected to be Moderate to Moderate-Tough based on NTA trends'
+  - 'Biology section likely easier than Physics/Chemistry — maximize your bio score'
+  - 'Expected General category cutoff: 720-730 out of 720 for top AIIMs'
+  - 'Qualifying cutoff expected around 135-145 for General category'
+  - 'Paper difficulty directly impacts cutoff — tougher paper = lower cutoff'
+---
+
+# NEET 2026 Difficulty Level & Cutoff Prediction
+
+Every NEET aspirant wants to know: **How tough will NEET 2026 be?** This guide provides a data-backed analysis of expected difficulty, cutoff trends, and what it means for your preparation strategy.
+
+## NEET Difficulty Trend: 5-Year Analysis
+
+| Year | Overall Difficulty | Biology       | Physics        | Chemistry      | Qualifying Cutoff (General) |
+| ---- | ------------------ | ------------- | -------------- | -------------- | --------------------------- |
+| 2021 | Moderate           | Easy-Moderate | Moderate       | Moderate       | 138                         |
+| 2022 | Moderate-Tough     | Moderate      | Tough          | Moderate       | 117                         |
+| 2023 | Moderate           | Easy-Moderate | Moderate       | Moderate-Tough | 137                         |
+| 2024 | Moderate           | Moderate      | Moderate-Tough | Moderate       | 164                         |
+| 2025 | Moderate-Tough     | Moderate      | Tough          | Moderate-Tough | 145 (est.)                  |
+
+**Key Pattern:** NTA alternates between moderate and moderate-tough papers. After the moderate-tough NEET 2025, NEET 2026 is likely to be **Moderate to Moderate-Tough**.
+
+---
+
+## NEET 2026 Expected Difficulty by Subject
+
+### Biology (Botany + Zoology): Moderate
+
+Biology has traditionally been the most scoring section. Here is what to expect:
+
+**Expected Question Distribution:**
+| Difficulty Level | Number of Questions | Marks |
+|-----------------|-------------------|-------|
+| Easy (Direct NCERT) | 35-40 | 140-160 |
+| Moderate (Application-Based) | 35-40 | 140-160 |
+| Difficult (Analytical) | 10-20 | 40-80 |
+
+**What This Means For You:**
+
+- 35-40 questions will come directly from NCERT lines and diagrams
+- Expect 8-10 assertion-reason type questions
+- Diagram-based questions increasing every year (expect 12-15)
+- Human Physiology and Genetics will dominate the tough questions
+
+### Physics: Moderate-Tough
+
+Physics remains the most challenging section for biology students:
+
+- Expect 15-18 numerical problems requiring calculations
+- Optics, Modern Physics, and Mechanics will have tougher questions
+- 10-12 questions will be straightforward formula-based
+
+### Chemistry: Moderate
+
+Chemistry balances between easy and tough:
+
+- Organic Chemistry: Moderate (reaction mechanisms increasing)
+- Inorganic Chemistry: Easy-Moderate (NCERT-heavy)
+- Physical Chemistry: Moderate-Tough (numerical-heavy)
+
+---
+
+## Category-Wise Expected Cutoff for NEET 2026
+
+### Qualifying Cutoff (50th Percentile)
+
+| Category     | Expected Cutoff Range | Previous Year Reference |
+| ------------ | --------------------- | ----------------------- |
+| General (UR) | 135-150               | 145 (2025)              |
+| OBC          | 120-135               | 129 (2025)              |
+| SC           | 100-115               | 105 (2025)              |
+| ST           | 95-110                | 100 (2025)              |
+| General-EWS  | 130-145               | 140 (2025)              |
+| PwD          | 120-135               | 129 (2025)              |
+
+### Cutoff for Top Government Medical Colleges
+
+| College Tier                    | Expected Score | Expected Rank |
+| ------------------------------- | -------------- | ------------- |
+| AIIMS New Delhi                 | 710-720        | Top 50        |
+| Top 5 AIIMS                     | 700-715        | Top 200       |
+| Top Government Colleges (State) | 650-690        | Top 5,000     |
+| Average Government Colleges     | 580-650        | Top 25,000    |
+| All Government Colleges         | 500-580        | Top 80,000    |
+| Private Colleges (Low Fee)      | 450-520        | Top 1,50,000  |
+| Private Colleges (High Fee)     | 350-450        | Top 4,00,000  |
+
+---
+
+## How Paper Difficulty Affects Your Rank
+
+This is a crucial concept many students miss:
+
+### Easy Paper Scenario
+
+- More students score high → cutoff increases
+- Even small mistakes cost many ranks
+- Topper scores: 715-720
+- Competition at top is extremely intense
+
+### Tough Paper Scenario
+
+- Fewer students score high → cutoff decreases
+- Each correct answer gains more ranks
+- Topper scores: 695-710
+- Rewards students who prepared tough topics
+
+### The Smart Strategy
+
+Regardless of difficulty:
+
+1. **Master NCERT first** — guarantees 280-320 marks in Biology even in tough papers
+2. **Practice application-based questions** — these differentiate moderate from tough papers
+3. **Build exam temperament** — take 40+ full-length mock tests before the exam
+4. **Have a time management plan** — decide your attempt order based on difficulty on exam day
+
+---
+
+## Subject-Wise Strategy Based on Expected Difficulty
+
+### If Biology Is Easy (Most Likely)
+
+- Target 340-360 out of 360
+- Do NOT spend extra time here — finish in 45-50 minutes
+- Accuracy matters more than time spent
+- Check diagrams carefully — easy papers have tricky diagram labels
+
+### If Biology Is Moderate
+
+- Target 300-340 out of 360
+- Spend 50-55 minutes maximum
+- Skip genuinely tough questions — come back in round 2
+- Focus on Human Physiology and Genetics first (highest weightage)
+
+### If Physics Is Tough (Expected)
+
+- Target 120-140 out of 180
+- Attempt all theory-based questions first
+- Leave complex numericals for the end
+- Do not waste more than 3 minutes on any single question
+
+### If Chemistry Is Moderate (Expected)
+
+- Target 140-160 out of 180
+- Start with Inorganic — quickest to solve
+- Physical Chemistry numericals — attempt selectively
+- Organic reaction questions — practice mechanism-based solving
+
+---
+
+## NEET 2026 Expected Changes and Updates
+
+### Confirmed/Expected Pattern Changes
+
+| Aspect          | NEET 2025            | Expected NEET 2026   |
+| --------------- | -------------------- | -------------------- |
+| Total Questions | 200 (attempt 180)    | 200 (attempt 180)    |
+| Duration        | 3 hours 20 minutes   | 3 hours 20 minutes   |
+| Marking         | +4 correct, -1 wrong | +4 correct, -1 wrong |
+| Mode            | Offline (OMR)        | Offline (OMR)        |
+| Languages       | 13 languages         | 13 languages         |
+| Exam Centers    | 500+ cities          | 500+ cities          |
+
+### What NTA Might Change
+
+- Increased assertion-reason questions (trend from 2024-2025)
+- More application-based questions from NCERT Exemplar
+- Possible increase in diagram/figure-based questions
+- Case-study based questions (introduced in 2024, likely to continue)
+
+---
+
+## Score vs Rank Prediction for NEET 2026
+
+| Score Range | Expected Rank Range | College Chances          |
+| ----------- | ------------------- | ------------------------ |
+| 700-720     | 1-100               | AIIMS Delhi, Top AIIMS   |
+| 680-700     | 100-500             | AIIMS, JIPMER, Top GMCs  |
+| 650-680     | 500-3,000           | State GMCs (Home State)  |
+| 620-650     | 3,000-8,000         | Good GMCs                |
+| 580-620     | 8,000-25,000        | Average GMCs             |
+| 550-580     | 25,000-50,000       | Lower GMCs, Top Private  |
+| 500-550     | 50,000-1,00,000     | Private Medical Colleges |
+| 450-500     | 1,00,000-2,00,000   | Private (Higher Fee)     |
+| 400-450     | 2,00,000-4,00,000   | Deemed Universities      |
+
+---
+
+## Month-by-Month Preparation Based on Difficulty Prediction
+
+### February-March 2026: Foundation Lock
+
+- Complete NCERT reading for all subjects
+- Score target in mock tests: 450-500
+
+### April 2026: Intensive Practice
+
+- Solve 5,000+ MCQs across all subjects
+- Focus on weak chapters identified in mocks
+- Score target: 550-580
+
+### May 2026 (Pre-Exam): Peak Performance
+
+- Full-length mock tests every alternate day
+- Revise high-weightage chapters only
+- Score target: 600+
+- Practice OMR filling speed
+
+---
+
+## Common Myths About NEET Difficulty
+
+### Myth 1: "Tough paper means I cannot score well"
+
+**Reality:** A tough paper is actually better for well-prepared students because the cutoff drops significantly. In NEET 2022 (tough paper), the qualifying cutoff dropped to 117.
+
+### Myth 2: "Easy paper means everyone will score high"
+
+**Reality:** Even in easy papers, the average score does not increase proportionally. Silly mistakes, time management issues, and negative marking still differentiate students.
+
+### Myth 3: "NTA makes the paper deliberately tougher each year"
+
+**Reality:** NTA aims for consistent difficulty. Variations happen due to question selection, not deliberate difficulty changes. The psychometric analysis ensures comparable scores across years.
+
+### Myth 4: "Previous year cutoffs are useless for prediction"
+
+**Reality:** Cutoff trends are the most reliable predictor. They account for difficulty, competition, and seat availability — all factors that change gradually.
+
+---
+
+## Final Verdict: What to Expect in NEET 2026
+
+| Factor                    | Prediction                           | Confidence |
+| ------------------------- | ------------------------------------ | ---------- |
+| Overall Difficulty        | Moderate to Moderate-Tough           | High       |
+| Biology Difficulty        | Moderate (slightly easier than 2025) | High       |
+| Physics Difficulty        | Moderate-Tough                       | Medium     |
+| Chemistry Difficulty      | Moderate                             | Medium     |
+| General Qualifying Cutoff | 135-150                              | Medium     |
+| Topper Score              | 710-720                              | High       |
+| Total Registrations       | 24-25 lakh                           | High       |
+
+**Bottom Line:** Do not waste time predicting difficulty. Prepare for a tough paper, and if it turns out easy, you will score even higher. The students who score 650+ prepare the same way regardless of expected difficulty.
+
+---
+
+## How Cerebrum Biology Academy Prepares You for Any Difficulty
+
+Our NEET Biology program is designed to handle any paper difficulty:
+
+- **NCERT Mastery Module**: Covers every line, diagram, and table from NCERT — handles easy papers
+- **Application-Based Training**: 500+ higher-order thinking questions — handles moderate papers
+- **Advanced Problem Solving**: Case studies, assertion-reason, and multi-concept problems — handles tough papers
+- **Weekly Mock Tests**: Simulated NEET conditions with detailed analysis
+
+Whether NEET 2026 is easy or tough, our students are prepared for both. [Explore our courses →](/courses)

--- a/content/blog/neet-biology-assertion-reason-diagram-questions-guide.mdx
+++ b/content/blog/neet-biology-assertion-reason-diagram-questions-guide.mdx
@@ -1,0 +1,408 @@
+---
+title: 'NEET Biology Assertion-Reason & Diagram Questions: Complete Practice Guide'
+slug: neet-biology-assertion-reason-diagram-questions-guide
+excerpt: 'Master the two trickiest question types in NEET Biology. Proven strategies for assertion-reason and diagram-based questions with 50+ practice MCQs and detailed explanations.'
+author:
+  name: 'Dr. Shekhar'
+  role: 'Founder & Senior Faculty'
+category: neet-preparation
+tags:
+  [
+    'NEET 2026',
+    'Assertion Reason',
+    'Diagram Questions',
+    'NEET Biology MCQ',
+    'Practice Questions',
+    'NCERT',
+    'Exam Strategy',
+  ]
+featuredImage: '/blog/assertion-reason-guide.svg'
+publishedAt: '2026-02-05'
+updatedAt: '2026-02-05'
+readTime: 20
+isPublished: true
+seoTitle: 'NEET Biology Assertion-Reason & Diagram Questions - 50+ Practice MCQs with Solutions'
+seoDescription: 'Complete guide to solving NEET Biology assertion-reason and diagram-based questions. 50+ practice MCQs with explanations. Scoring strategy for these high-frequency question types.'
+views: 38920
+difficulty: 'Intermediate'
+neetChapter: 'General'
+neetWeightage: 'High'
+targetAudience: 'Both'
+keyTakeaways:
+  - 'NEET 2026 will have 8-12 assertion-reason questions across all subjects'
+  - 'Diagram-based questions contribute 12-15 marks in Biology every year'
+  - 'Both question types reward NCERT-focused preparation above all else'
+  - 'A systematic 4-step approach can solve 90% of assertion-reason questions'
+  - 'Practice with diagrams from NCERT figures — most questions come directly from them'
+---
+
+# NEET Biology Assertion-Reason & Diagram Questions
+
+Two question types consistently trouble NEET aspirants: **assertion-reason (A-R)** and **diagram-based questions**. Together, they contribute 20-30 marks in Biology alone. Mastering them can be the difference between 300 and 340 in Biology.
+
+## Part 1: Assertion-Reason Questions
+
+### What Are Assertion-Reason Questions?
+
+In these questions, two statements are given:
+
+- **Assertion (A):** A factual statement
+- **Reason (R):** An explanation or related statement
+
+You must evaluate both statements AND their relationship.
+
+### The 4 Answer Options
+
+| Option  | Meaning                                                          |
+| ------- | ---------------------------------------------------------------- |
+| **(a)** | Both A and R are true, and R is the correct explanation of A     |
+| **(b)** | Both A and R are true, but R is NOT the correct explanation of A |
+| **(c)** | A is true, but R is false                                        |
+| **(d)** | A is false, but R is true                                        |
+
+**Note:** Some NEET papers include a 5th option where both are false. Always read the options carefully.
+
+### The 4-Step Solving Strategy
+
+**Step 1: Evaluate Assertion (A) independently**
+
+- Is this statement factually correct?
+- Can you recall this from NCERT?
+- If A is false → answer is (d) (if R is true) or both false
+
+**Step 2: Evaluate Reason (R) independently**
+
+- Is this statement factually correct on its own?
+- Do not think about its relationship to A yet
+- If R is false → answer is (c) (assuming A is true)
+
+**Step 3: Check if both are true**
+
+- If both are true, proceed to Step 4
+- If only one is true, you already have your answer
+
+**Step 4: Check the relationship**
+
+- Does R actually explain WHY A is true?
+- Is there a cause-effect relationship?
+- If yes → (a). If no → (b)
+
+---
+
+### Practice Questions: Genetics
+
+**Q1.**
+**Assertion (A):** In Mendel's monohybrid cross, the F2 phenotypic ratio is 3:1.
+**Reason (R):** During gamete formation, alleles segregate so that each gamete receives only one allele.
+
+**Answer:** (a)
+**Explanation:** Both statements are true. The 3:1 ratio (A) occurs precisely because of the law of segregation (R). R directly explains why A happens — alleles separate during gamete formation, and random combination in F2 produces the 3:1 ratio.
+
+---
+
+**Q2.**
+**Assertion (A):** Haemophilia is more common in males than females.
+**Reason (R):** Haemophilia is an autosomal recessive disorder.
+
+**Answer:** (c)
+**Explanation:** A is true — haemophilia is indeed more common in males. But R is false — haemophilia is X-linked recessive, not autosomal recessive. Males need only one copy of the defective allele (XʰY) while females need two (XʰXʰ), making it rarer in females.
+
+---
+
+**Q3.**
+**Assertion (A):** Turner's syndrome individuals are sterile females with 45 chromosomes.
+**Reason (R):** Turner's syndrome is caused by monosomy of the X chromosome (44+XO).
+
+**Answer:** (a)
+**Explanation:** Both are true, and R correctly explains A. The monosomy of X chromosome (45,XO karyotype) directly causes the female phenotype with sterility — the missing X chromosome leads to underdeveloped ovaries and infertility.
+
+---
+
+**Q4.**
+**Assertion (A):** A cross between a homozygous red-flowered plant and a white-flowered plant in snapdragon produces pink flowers.
+**Reason (R):** This is an example of codominance.
+
+**Answer:** (c)
+**Explanation:** A is true — snapdragon shows pink flowers in F1. But R is false — this is incomplete dominance, not codominance. In incomplete dominance, the heterozygote shows a blended phenotype (pink). In codominance, both alleles express simultaneously (like ABO blood groups where AB shows both A and B antigens).
+
+---
+
+**Q5.**
+**Assertion (A):** DNA replication is semi-conservative.
+**Reason (R):** Meselson and Stahl proved this using heavy nitrogen (¹⁵N) labeling in E. coli.
+
+**Answer:** (a)
+**Explanation:** Both are true. Semi-conservative replication (A) was experimentally proven by the Meselson-Stahl experiment (R) using density gradient centrifugation of ¹⁵N-labeled DNA. The experiment directly demonstrated that each new DNA molecule contains one old and one new strand.
+
+---
+
+### Practice Questions: Human Physiology
+
+**Q6.**
+**Assertion (A):** Tidal volume is approximately 500 mL.
+**Reason (R):** Tidal volume is the amount of air inspired or expired during normal breathing.
+
+**Answer:** (a)
+**Explanation:** Both statements are true, and R explains A. During normal quiet breathing (defined by R), approximately 500 mL of air moves in and out per breath (A). The definition of tidal volume directly determines its measured value.
+
+---
+
+**Q7.**
+**Assertion (A):** Bile juice contains no digestive enzymes.
+**Reason (R):** Bile is produced by the gallbladder.
+
+**Answer:** (c)
+**Explanation:** A is true — bile contains bile salts and bile pigments but no digestive enzymes. It emulsifies fats but does not enzymatically digest them. R is false — bile is produced by the liver (hepatocytes), not the gallbladder. The gallbladder only stores and concentrates bile.
+
+---
+
+**Q8.**
+**Assertion (A):** The SA node is called the pacemaker of the heart.
+**Reason (R):** The SA node generates the maximum rate of action potentials in the heart.
+
+**Answer:** (a)
+**Explanation:** Both are true, and R explains A. The SA node is called the pacemaker (A) because it has the highest intrinsic rate of action potential generation (~70-75 beats/min), which drives the rhythmic contraction of the entire heart. Other nodes (AV node, Bundle of His) have slower rates and follow the SA node's lead.
+
+---
+
+**Q9.**
+**Assertion (A):** Urine is hypotonic when it reaches the collecting duct.
+**Reason (R):** The ascending limb of the loop of Henle is impermeable to water.
+
+**Answer:** (a)
+**Explanation:** Both are true and R explains A. The ascending limb actively transports NaCl out but does not allow water to follow (impermeable to water, R). This creates a dilute (hypotonic) filtrate that reaches the collecting duct (A). The collecting duct then concentrates urine based on ADH levels.
+
+---
+
+**Q10.**
+**Assertion (A):** Myasthenia gravis is an autoimmune disease affecting neuromuscular junctions.
+**Reason (R):** Antibodies attack acetylcholine receptors, leading to muscle weakness.
+
+**Answer:** (a)
+**Explanation:** Both are true, and R correctly explains A. In myasthenia gravis, the immune system produces antibodies against acetylcholine receptors at the neuromuscular junction (R). This reduces signal transmission from nerve to muscle, causing progressive muscle weakness (A).
+
+---
+
+### Practice Questions: Ecology and Evolution
+
+**Q11.**
+**Assertion (A):** The pyramid of energy is always upright.
+**Reason (R):** Energy transfer between trophic levels follows the 10% law.
+
+**Answer:** (a)
+**Explanation:** Both are true, and R explains A. At each trophic level, only about 10% of energy is transferred to the next level (R). This means energy always decreases as you go up trophic levels, making the pyramid always upright (A). Unlike biomass or number pyramids, energy pyramids can never be inverted.
+
+---
+
+**Q12.**
+**Assertion (A):** Darwin's finches are an example of adaptive radiation.
+**Reason (R):** All finches evolved from a common ancestor and adapted to different ecological niches.
+
+**Answer:** (a)
+**Explanation:** Both are true, and R explains A. Darwin's finches on the Galapagos Islands descended from a single ancestor species (R) and diversified into 14+ species with different beak shapes adapted to different food sources. This divergent evolution from a common ancestor into multiple forms is the definition of adaptive radiation (A).
+
+---
+
+**Q13.**
+**Assertion (A):** Lichens are good indicators of air pollution.
+**Reason (R):** Lichens can tolerate high levels of sulfur dioxide.
+
+**Answer:** (c)
+**Explanation:** A is true — lichens are indeed bioindicators of air quality. However, R is false — lichens are extremely sensitive to SO₂ and other pollutants. They disappear from areas with high air pollution. Their sensitivity (not tolerance) is what makes them useful indicators — their absence signals polluted air.
+
+---
+
+**Q14.**
+**Assertion (A):** Primary succession on bare rock begins with lichen colonization.
+**Reason (R):** Lichens secrete acids that help in weathering of rock to form soil.
+
+**Answer:** (a)
+**Explanation:** Both are true, and R explains A. Lichens are pioneer species on bare rock (A) because they can grow on hard surfaces and secrete organic acids that gradually break down rock into soil (R). This soil formation allows subsequent species (mosses, then grasses, then shrubs) to establish.
+
+---
+
+### Practice Questions: Cell Biology and Biomolecules
+
+**Q15.**
+**Assertion (A):** Mitochondria are called the powerhouse of the cell.
+**Reason (R):** Mitochondria contain their own circular DNA and ribosomes.
+
+**Answer:** (b)
+**Explanation:** Both statements are true, but R does not explain A. Mitochondria are called the powerhouse because they produce ATP through oxidative phosphorylation (the actual reason). The fact that they have their own DNA and ribosomes (R) relates to the endosymbiotic theory of their origin, not to their energy-producing function.
+
+---
+
+**Q16.**
+**Assertion (A):** Enzymes lower the activation energy of a reaction.
+**Reason (R):** Enzymes are consumed during the reaction they catalyze.
+
+**Answer:** (c)
+**Explanation:** A is true — enzymes lower activation energy by providing an alternative reaction pathway with lower energy barriers. R is false — enzymes are biological catalysts that remain unchanged after the reaction. They can be reused for multiple reaction cycles, which is why small amounts of enzyme can process large amounts of substrate.
+
+---
+
+**Q17.**
+**Assertion (A):** The cell wall of fungi is made of chitin.
+**Reason (R):** Chitin is a polymer of N-acetylglucosamine.
+
+**Answer:** (b)
+**Explanation:** Both are true, but R does not explain A. The fungal cell wall is indeed made of chitin (A), and chitin is a polymer of N-acetylglucosamine (R). However, the chemical composition of chitin does not explain why fungi use chitin for their cell wall rather than cellulose (used by plants) or peptidoglycan (used by bacteria).
+
+---
+
+### Common Traps in Assertion-Reason Questions
+
+| Trap                                        | How to Avoid It                                                             |
+| ------------------------------------------- | --------------------------------------------------------------------------- |
+| Both statements seem related                | Ask: "Does R CAUSE or EXPLAIN A?" not just "Are they about the same topic?" |
+| R is a true but unrelated fact              | A true statement is not automatically the explanation                       |
+| A uses extreme language ("always", "never") | Check if there are exceptions — extreme words often signal false statements |
+| R reverses cause and effect                 | Verify the direction: R should explain A, not the other way                 |
+| Both statements are from different chapters | Cross-chapter A-R pairs usually have answer (b) — true but unrelated        |
+
+---
+
+## Part 2: Diagram-Based Questions
+
+### Why Diagram Questions Matter
+
+| Fact                            | Data                   |
+| ------------------------------- | ---------------------- |
+| Diagram questions per year      | 12-15 in Biology       |
+| Marks at stake                  | 48-60 marks            |
+| Source of diagrams              | 95% from NCERT figures |
+| Students who skip diagram study | ~60%                   |
+
+### High-Frequency NCERT Diagrams You Must Know
+
+#### Class 11 Biology: Must-Know Diagrams
+
+| Chapter        | Critical Diagrams                                                                  | Question Frequency |
+| -------------- | ---------------------------------------------------------------------------------- | ------------------ |
+| Cell Structure | Prokaryotic vs Eukaryotic cell, Mitochondria ultrastructure, Chloroplast structure | Every year         |
+| Cell Division  | Stages of mitosis, Meiosis I and II, Cell cycle diagram                            | Every year         |
+| Plant Kingdom  | Life cycles (Moss, Fern), Alternation of generations                               | Alternate years    |
+| Biomolecules   | Enzyme-substrate model (Lock and Key, Induced fit), Protein structure levels       | Frequently         |
+| Photosynthesis | Z-scheme, Calvin cycle, C4 pathway (Hatch-Slack)                                   | Every year         |
+| Respiration    | Glycolysis, Krebs cycle, ETS components                                            | Every year         |
+| Plant Anatomy  | T.S. of dicot and monocot stem/root/leaf                                           | Frequently         |
+
+#### Class 12 Biology: Must-Know Diagrams
+
+| Chapter            | Critical Diagrams                                                                 | Question Frequency |
+| ------------------ | --------------------------------------------------------------------------------- | ------------------ |
+| Human Reproduction | Sperm structure, Ovum structure, Menstrual cycle graph, Embryo development stages | Every year         |
+| Genetics           | Dihybrid cross checker board, Pedigree analysis symbols, DNA replication fork     | Every year         |
+| Molecular Biology  | Lac operon diagram, Transcription unit, Translation process                       | Every year         |
+| Ecology            | Food web, Energy flow diagram, Ecological pyramids, Nutrient cycling              | Every year         |
+| Evolution          | Homologous vs Analogous organs, Darwin's finch beaks, Human evolution timeline    | Frequently         |
+| Biotechnology      | PCR steps, Gel electrophoresis, Recombinant DNA technology steps                  | Frequently         |
+| Human Physiology   | Heart diagram, Nephron structure, Reflex arc, Synapse                             | Every year         |
+
+### How to Study Diagrams Effectively
+
+**The 3-Layer Approach:**
+
+**Layer 1: Recognize**
+
+- Can you identify the diagram without labels?
+- Practice with blank diagrams — fill in labels from memory
+
+**Layer 2: Label**
+
+- Memorize every label shown in NCERT
+- Pay attention to arrows (direction matters in cycles)
+- Note specific numbers (e.g., 36-38 ATP in respiration)
+
+**Layer 3: Explain**
+
+- Can you explain what happens at each labeled point?
+- Understand the process the diagram represents
+- Connect the diagram to related concepts
+
+### Practice: Diagram Identification Questions
+
+**Q18.** A diagram shows a structure with an outer membrane, inner membrane with cristae, matrix containing circular DNA, and 70S ribosomes. Identify the organelle and its primary function.
+
+**Answer:** Mitochondrion. Primary function is aerobic cellular respiration (oxidative phosphorylation) producing ATP. The cristae increase surface area for the electron transport chain. The matrix contains enzymes for the Krebs cycle.
+
+---
+
+**Q19.** In a diagram of a nephron, the structure between the Bowman's capsule and the loop of Henle is labeled X. Structure X and its primary function are:
+
+**Answer:** Structure X is the Proximal Convoluted Tubule (PCT). Its primary function is obligatory reabsorption of approximately 65-70% of water, all glucose, all amino acids, and most electrolytes from the glomerular filtrate. It has brush border microvilli to increase surface area for reabsorption.
+
+---
+
+**Q20.** A graph shows hormone levels during the menstrual cycle. Peak A occurs around day 14, Peak B is sustained from day 15-28 and drops sharply if no fertilization occurs. Identify hormones A and B.
+
+**Answer:** Peak A is LH (Luteinizing Hormone) — the LH surge triggers ovulation around day 14. Peak B is Progesterone — secreted by the corpus luteum after ovulation, it maintains the endometrium for potential implantation. If no fertilization occurs, the corpus luteum degenerates, progesterone drops, and menstruation begins.
+
+---
+
+**Q21.** A diagram shows the Z-scheme of light reactions. The component that splits water molecules is located at what position?
+
+**Answer:** The water-splitting complex (OEC - Oxygen Evolving Complex) is associated with Photosystem II (PS II). It is located on the inner side (lumen side) of the thylakoid membrane. The reaction: 2H₂O → 4H⁺ + 4e⁻ + O₂. The electrons replace those lost by P680 (reaction center of PS II) when it absorbs light.
+
+---
+
+### Diagram Question Strategies
+
+| Strategy                | How to Apply                                                     |
+| ----------------------- | ---------------------------------------------------------------- |
+| Label everything first  | Before reading options, mentally label the diagram               |
+| Follow the arrows       | Arrows show direction of flow (blood, filtrate, electrons)       |
+| Count the structures    | Questions often ask "how many" — count carefully                 |
+| Check for common errors | NTA sometimes has intentional errors in diagrams — identify them |
+| Relate to process       | Connect the static diagram to the dynamic process it represents  |
+
+---
+
+## Combined Strategy: Scoring 40+ Marks from A-R and Diagram Questions
+
+### Daily Practice Routine
+
+| Day       | Practice Activity                               | Time   |
+| --------- | ----------------------------------------------- | ------ |
+| Monday    | 10 assertion-reason (Genetics)                  | 30 min |
+| Tuesday   | 5 diagram identifications (Cell Biology)        | 30 min |
+| Wednesday | 10 assertion-reason (Physiology)                | 30 min |
+| Thursday  | 5 diagram identifications (Ecology + Evolution) | 30 min |
+| Friday    | 10 assertion-reason (Ecology + Botany)          | 30 min |
+| Saturday  | Mixed — 10 A-R + 5 diagrams (all topics)        | 45 min |
+| Sunday    | Review wrong answers from the week              | 30 min |
+
+### Quick Reference: Answer Distribution in Past Papers
+
+| Answer Option                       | Frequency in Past A-R Questions |
+| ----------------------------------- | ------------------------------- |
+| (a) Both true, R explains A         | ~35%                            |
+| (b) Both true, R does NOT explain A | ~25%                            |
+| (c) A true, R false                 | ~25%                            |
+| (d) A false, R true                 | ~15%                            |
+
+**Key Insight:** Option (a) is most common, but do not default to it. Always verify the explanation relationship.
+
+---
+
+## Key Takeaways for Exam Day
+
+1. **Read assertion and reason SEPARATELY first** — evaluate each as an independent true/false statement
+2. **Only check the relationship if BOTH are true** — saves time when one is false
+3. **For diagrams, label mentally before reading options** — prevents options from confusing you
+4. **NCERT diagrams are your primary source** — 95% of diagram questions come from NCERT figures
+5. **Do not spend more than 90 seconds per A-R question** — if confused, mark and move on
+6. **Practice 10 A-R questions daily for 30 days** — builds pattern recognition
+
+---
+
+## Master These Question Types with Expert Guidance
+
+At Cerebrum Biology Academy, our NEET Biology program includes dedicated modules for:
+
+- **Assertion-Reason workshops** with 200+ practice questions and detailed solutions
+- **Diagram mastery sessions** covering every NCERT figure with practice
+- **Weekly mock tests** featuring the latest NEET question patterns
+- **One-on-one doubt clearing** for tricky A-R and diagram questions
+
+Do not let these question types cost you marks. [Explore our courses →](/courses)

--- a/src/app/blog/layout.tsx
+++ b/src/app/blog/layout.tsx
@@ -1,0 +1,10 @@
+import { BlogCategoryNav } from '@/components/blog/BlogCategoryNav'
+
+export default function BlogLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <>
+      <BlogCategoryNav />
+      {children}
+    </>
+  )
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from 'next'
 import { Suspense } from 'react'
 import nextDynamic from 'next/dynamic'
-import { getAllPosts, getAllCategories, getBlogStats } from '@/lib/blog/mdx'
+import { getAllPosts, getAllCategories, getBlogStats, getAllTags } from '@/lib/blog/mdx'
 import { BreadcrumbSchema } from '@/components/seo'
 
 // Force dynamic rendering to ensure searchParams work correctly
@@ -66,6 +66,8 @@ export default function BlogPage() {
   const posts = getAllPosts()
   const categories = getAllCategories()
   const stats = getBlogStats()
+  const tags = getAllTags()
+  const popularTags = tags.slice(0, 15)
 
   return (
     <>
@@ -75,7 +77,12 @@ export default function BlogPage() {
       </div>
       {/* Suspense boundary required for useSearchParams in BlogListingPage */}
       <Suspense fallback={<BlogLoadingSkeleton />}>
-        <BlogListingPage posts={posts} categories={categories} stats={stats} />
+        <BlogListingPage
+          posts={posts}
+          categories={categories}
+          stats={stats}
+          popularTags={popularTags}
+        />
       </Suspense>
     </>
   )

--- a/src/components/blog/BlogCategoryNav.tsx
+++ b/src/components/blog/BlogCategoryNav.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { blogCategories } from '@/lib/blog/mdx'
+
+const categories = Object.values(blogCategories)
+
+export function BlogCategoryNav() {
+  const pathname = usePathname()
+
+  const isAllPosts = pathname === '/blog'
+  const activeCategorySlug = pathname.startsWith('/blog/category/')
+    ? pathname.replace('/blog/category/', '')
+    : null
+
+  return (
+    <nav className="sticky top-0 z-40 bg-white/95 backdrop-blur-md border-b border-gray-200 shadow-sm">
+      <div className="max-w-7xl mx-auto px-4">
+        <div className="flex items-center gap-2 py-3 overflow-x-auto scrollbar-hide">
+          <Link
+            href="/blog"
+            className={`flex-shrink-0 px-4 py-1.5 rounded-full text-sm font-medium transition-colors ${
+              isAllPosts ? 'bg-[#4a5d4a] text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+            }`}
+          >
+            All Posts
+          </Link>
+          {categories.map((cat) => {
+            const isActive = activeCategorySlug === cat.slug
+            return (
+              <Link
+                key={cat.slug}
+                href={`/blog/category/${cat.slug}`}
+                className={`flex-shrink-0 px-4 py-1.5 rounded-full text-sm font-medium transition-colors whitespace-nowrap ${
+                  isActive ? cat.color : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                }`}
+              >
+                {cat.name}
+              </Link>
+            )
+          })}
+        </div>
+      </div>
+    </nav>
+  )
+}

--- a/src/components/blog/CategoryArchivePage.tsx
+++ b/src/components/blog/CategoryArchivePage.tsx
@@ -1,11 +1,16 @@
 'use client'
 
+import { useState, useMemo, useCallback } from 'react'
 import { BlogPostMeta, BlogCategory } from '@/types/blog'
 import Link from 'next/link'
-import { ArrowLeft, Clock, Eye, User, BookOpen, Folder } from 'lucide-react'
+import { Clock, Eye, User, BookOpen, Folder, ArrowUpDown } from 'lucide-react'
 import { DifficultyBadge } from './DifficultyBadge'
 import { NEETTopicBadge } from './NEETTopicBadge'
 import { BlogThumbnail } from './BlogThumbnail'
+import { BlogPagination } from './BlogPagination'
+
+type SortOption = 'newest' | 'popular' | 'readTime'
+const POSTS_PER_PAGE = 9
 
 interface CategoryArchivePageProps {
   category: BlogCategory
@@ -13,21 +18,42 @@ interface CategoryArchivePageProps {
 }
 
 export function CategoryArchivePage({ category, posts }: CategoryArchivePageProps) {
+  const [sortBy, setSortBy] = useState<SortOption>('newest')
+  const [currentPage, setCurrentPage] = useState(1)
+
+  const sortedPosts = useMemo(() => {
+    const result = [...posts]
+    switch (sortBy) {
+      case 'popular':
+        return result.sort((a, b) => (b.views || 0) - (a.views || 0))
+      case 'readTime':
+        return result.sort((a, b) => (a.readTime || 0) - (b.readTime || 0))
+      case 'newest':
+      default:
+        return result.sort(
+          (a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
+        )
+    }
+  }, [posts, sortBy])
+
+  const totalPages = Math.ceil(sortedPosts.length / POSTS_PER_PAGE)
+
+  const paginatedPosts = useMemo(() => {
+    return sortedPosts.slice((currentPage - 1) * POSTS_PER_PAGE, currentPage * POSTS_PER_PAGE)
+  }, [sortedPosts, currentPage])
+
+  const handlePageChange = useCallback((page: number) => {
+    setCurrentPage(page)
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }, [])
+
+  const handleSortChange = useCallback((newSort: SortOption) => {
+    setSortBy(newSort)
+    setCurrentPage(1)
+  }, [])
+
   return (
     <div className="min-h-screen bg-white">
-      {/* Back Button */}
-      <div className="bg-gray-50 border-b">
-        <div className="max-w-7xl mx-auto px-4 py-4">
-          <Link
-            href="/blog"
-            className="inline-flex items-center text-gray-600 hover:text-blue-600 transition-colors"
-          >
-            <ArrowLeft className="w-4 h-4 mr-2" />
-            Back to Blog
-          </Link>
-        </div>
-      </div>
-
       {/* Hero Section */}
       <section className="bg-blue-600 text-white py-16">
         <div className="max-w-7xl mx-auto px-4 text-center">
@@ -44,6 +70,28 @@ export function CategoryArchivePage({ category, posts }: CategoryArchivePageProp
               <BookOpen className="w-5 h-5" />
               <span className="font-semibold">{posts.length} Articles</span>
             </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Sort Bar */}
+      <section className="border-b bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4 py-4 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
+          <span className="text-sm text-gray-600">
+            Showing {paginatedPosts.length} of {sortedPosts.length} articles
+          </span>
+          <div className="flex items-center gap-2">
+            <ArrowUpDown className="w-4 h-4 text-gray-500" />
+            <select
+              value={sortBy}
+              onChange={(e) => handleSortChange(e.target.value as SortOption)}
+              className="px-3 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white text-sm font-medium"
+              aria-label="Sort articles"
+            >
+              <option value="newest">Newest First</option>
+              <option value="popular">Most Popular</option>
+              <option value="readTime">Quick Reads</option>
+            </select>
           </div>
         </div>
       </section>
@@ -66,66 +114,74 @@ export function CategoryArchivePage({ category, posts }: CategoryArchivePageProp
               </Link>
             </div>
           ) : (
-            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-              {posts.map((post) => (
-                <article
-                  key={post.slug}
-                  className="bg-white rounded-2xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow border border-gray-100 animate-fade-in"
-                >
-                  {/* Thumbnail */}
-                  <Link href={`/blog/${post.slug}`}>
-                    <BlogThumbnail
-                      slug={post.slug}
-                      title={post.title}
-                      size="md"
-                      className="rounded-none"
-                    />
-                  </Link>
+            <>
+              <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+                {paginatedPosts.map((post) => (
+                  <article
+                    key={post.slug}
+                    className="bg-white rounded-2xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow border border-gray-100 animate-fade-in"
+                  >
+                    {/* Thumbnail */}
+                    <Link href={`/blog/${post.slug}`}>
+                      <BlogThumbnail
+                        slug={post.slug}
+                        title={post.title}
+                        size="md"
+                        className="rounded-none"
+                      />
+                    </Link>
 
-                  <div className="p-6">
-                    {/* Badges */}
-                    <div className="flex flex-wrap gap-2 mb-3">
-                      {post.difficulty && (
-                        <DifficultyBadge difficulty={post.difficulty} size="sm" />
-                      )}
-                      {post.neetChapter && (
-                        <NEETTopicBadge
-                          chapter={post.neetChapter}
-                          weightage={post.neetWeightage}
-                          size="sm"
-                        />
-                      )}
-                    </div>
+                    <div className="p-6">
+                      {/* Badges */}
+                      <div className="flex flex-wrap gap-2 mb-3">
+                        {post.difficulty && (
+                          <DifficultyBadge difficulty={post.difficulty} size="sm" />
+                        )}
+                        {post.neetChapter && (
+                          <NEETTopicBadge
+                            chapter={post.neetChapter}
+                            weightage={post.neetWeightage}
+                            size="sm"
+                          />
+                        )}
+                      </div>
 
-                    {/* Title */}
-                    <h2 className="text-lg font-bold text-gray-900 mb-3 line-clamp-2 hover:text-blue-600 transition-colors">
-                      <Link href={`/blog/${post.slug}`}>{post.title}</Link>
-                    </h2>
+                      {/* Title */}
+                      <h2 className="text-lg font-bold text-gray-900 mb-3 line-clamp-2 hover:text-blue-600 transition-colors">
+                        <Link href={`/blog/${post.slug}`}>{post.title}</Link>
+                      </h2>
 
-                    {/* Excerpt */}
-                    <p className="text-gray-600 text-sm mb-4 line-clamp-2">{post.excerpt}</p>
+                      {/* Excerpt */}
+                      <p className="text-gray-600 text-sm mb-4 line-clamp-2">{post.excerpt}</p>
 
-                    {/* Meta */}
-                    <div className="flex items-center justify-between text-xs text-gray-500 pt-4 border-t border-gray-100">
-                      <div className="flex items-center gap-3">
+                      {/* Meta */}
+                      <div className="flex items-center justify-between text-xs text-gray-500 pt-4 border-t border-gray-100">
+                        <div className="flex items-center gap-3">
+                          <span className="flex items-center">
+                            <Clock className="w-3 h-3 mr-1" />
+                            {post.readTime}m
+                          </span>
+                          <span className="flex items-center">
+                            <Eye className="w-3 h-3 mr-1" />
+                            {post.views?.toLocaleString()}
+                          </span>
+                        </div>
                         <span className="flex items-center">
-                          <Clock className="w-3 h-3 mr-1" />
-                          {post.readTime}m
-                        </span>
-                        <span className="flex items-center">
-                          <Eye className="w-3 h-3 mr-1" />
-                          {post.views?.toLocaleString()}
+                          <User className="w-3 h-3 mr-1" />
+                          {post.author.name}
                         </span>
                       </div>
-                      <span className="flex items-center">
-                        <User className="w-3 h-3 mr-1" />
-                        {post.author.name}
-                      </span>
                     </div>
-                  </div>
-                </article>
-              ))}
-            </div>
+                  </article>
+                ))}
+              </div>
+
+              <BlogPagination
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={handlePageChange}
+              />
+            </>
           )}
         </div>
       </section>

--- a/src/components/blog/TagArchivePage.tsx
+++ b/src/components/blog/TagArchivePage.tsx
@@ -1,12 +1,17 @@
 'use client'
 
+import { useState, useMemo, useCallback } from 'react'
 import { BlogPostMeta } from '@/types/blog'
 import { blogCategories } from '@/lib/blog/mdx'
 import Link from 'next/link'
-import { ArrowLeft, Clock, Eye, User, BookOpen, Tag, Hash } from 'lucide-react'
+import { Clock, Eye, User, BookOpen, Tag, Hash, ArrowUpDown } from 'lucide-react'
 import { DifficultyBadge } from './DifficultyBadge'
 import { NEETTopicBadge } from './NEETTopicBadge'
 import { BlogThumbnail } from './BlogThumbnail'
+import { BlogPagination } from './BlogPagination'
+
+type SortOption = 'newest' | 'popular' | 'readTime'
+const POSTS_PER_PAGE = 9
 
 interface TagArchivePageProps {
   tag: string
@@ -14,25 +19,46 @@ interface TagArchivePageProps {
 }
 
 export function TagArchivePage({ tag, posts }: TagArchivePageProps) {
+  const [sortBy, setSortBy] = useState<SortOption>('newest')
+  const [currentPage, setCurrentPage] = useState(1)
+
   const getCategoryInfo = (categorySlug: string) => {
     return blogCategories[categorySlug] || { name: 'General', color: 'bg-gray-100 text-gray-800' }
   }
 
+  const sortedPosts = useMemo(() => {
+    const result = [...posts]
+    switch (sortBy) {
+      case 'popular':
+        return result.sort((a, b) => (b.views || 0) - (a.views || 0))
+      case 'readTime':
+        return result.sort((a, b) => (a.readTime || 0) - (b.readTime || 0))
+      case 'newest':
+      default:
+        return result.sort(
+          (a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
+        )
+    }
+  }, [posts, sortBy])
+
+  const totalPages = Math.ceil(sortedPosts.length / POSTS_PER_PAGE)
+
+  const paginatedPosts = useMemo(() => {
+    return sortedPosts.slice((currentPage - 1) * POSTS_PER_PAGE, currentPage * POSTS_PER_PAGE)
+  }, [sortedPosts, currentPage])
+
+  const handlePageChange = useCallback((page: number) => {
+    setCurrentPage(page)
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }, [])
+
+  const handleSortChange = useCallback((newSort: SortOption) => {
+    setSortBy(newSort)
+    setCurrentPage(1)
+  }, [])
+
   return (
     <div className="min-h-screen bg-white">
-      {/* Back Button */}
-      <div className="bg-gray-50 border-b">
-        <div className="max-w-7xl mx-auto px-4 py-4">
-          <Link
-            href="/blog"
-            className="inline-flex items-center text-gray-600 hover:text-blue-600 transition-colors"
-          >
-            <ArrowLeft className="w-4 h-4 mr-2" />
-            Back to Blog
-          </Link>
-        </div>
-      </div>
-
       {/* Hero Section */}
       <section className="bg-indigo-600 text-white py-16">
         <div className="max-w-7xl mx-auto px-4 text-center">
@@ -55,6 +81,28 @@ export function TagArchivePage({ tag, posts }: TagArchivePageProps) {
         </div>
       </section>
 
+      {/* Sort Bar */}
+      <section className="border-b bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4 py-4 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
+          <span className="text-sm text-gray-600">
+            Showing {paginatedPosts.length} of {sortedPosts.length} articles
+          </span>
+          <div className="flex items-center gap-2">
+            <ArrowUpDown className="w-4 h-4 text-gray-500" />
+            <select
+              value={sortBy}
+              onChange={(e) => handleSortChange(e.target.value as SortOption)}
+              className="px-3 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white text-sm font-medium"
+              aria-label="Sort articles"
+            >
+              <option value="newest">Newest First</option>
+              <option value="popular">Most Popular</option>
+              <option value="readTime">Quick Reads</option>
+            </select>
+          </div>
+        </div>
+      </section>
+
       {/* Posts Grid */}
       <section className="py-12 px-4">
         <div className="max-w-7xl mx-auto">
@@ -73,90 +121,98 @@ export function TagArchivePage({ tag, posts }: TagArchivePageProps) {
               </Link>
             </div>
           ) : (
-            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-              {posts.map((post) => (
-                <article
-                  key={post.slug}
-                  className="bg-white rounded-2xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow border border-gray-100 animate-fade-in"
-                >
-                  {/* Thumbnail */}
-                  <Link href={`/blog/${post.slug}`}>
-                    <BlogThumbnail
-                      slug={post.slug}
-                      title={post.title}
-                      size="md"
-                      className="rounded-none"
-                    />
-                  </Link>
+            <>
+              <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+                {paginatedPosts.map((post) => (
+                  <article
+                    key={post.slug}
+                    className="bg-white rounded-2xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow border border-gray-100 animate-fade-in"
+                  >
+                    {/* Thumbnail */}
+                    <Link href={`/blog/${post.slug}`}>
+                      <BlogThumbnail
+                        slug={post.slug}
+                        title={post.title}
+                        size="md"
+                        className="rounded-none"
+                      />
+                    </Link>
 
-                  <div className="p-6">
-                    {/* Category Badge */}
-                    <div
-                      className={`inline-block px-3 py-1 rounded-full text-xs font-medium mb-3 ${getCategoryInfo(post.category).color}`}
-                    >
-                      {getCategoryInfo(post.category).name}
-                    </div>
+                    <div className="p-6">
+                      {/* Category Badge */}
+                      <div
+                        className={`inline-block px-3 py-1 rounded-full text-xs font-medium mb-3 ${getCategoryInfo(post.category).color}`}
+                      >
+                        {getCategoryInfo(post.category).name}
+                      </div>
 
-                    {/* Badges */}
-                    <div className="flex flex-wrap gap-2 mb-3">
-                      {post.difficulty && (
-                        <DifficultyBadge difficulty={post.difficulty} size="sm" />
-                      )}
-                      {post.neetChapter && (
-                        <NEETTopicBadge
-                          chapter={post.neetChapter}
-                          weightage={post.neetWeightage}
-                          size="sm"
-                        />
-                      )}
-                    </div>
+                      {/* Badges */}
+                      <div className="flex flex-wrap gap-2 mb-3">
+                        {post.difficulty && (
+                          <DifficultyBadge difficulty={post.difficulty} size="sm" />
+                        )}
+                        {post.neetChapter && (
+                          <NEETTopicBadge
+                            chapter={post.neetChapter}
+                            weightage={post.neetWeightage}
+                            size="sm"
+                          />
+                        )}
+                      </div>
 
-                    {/* Title */}
-                    <h2 className="text-lg font-bold text-gray-900 mb-3 line-clamp-2 hover:text-blue-600 transition-colors">
-                      <Link href={`/blog/${post.slug}`}>{post.title}</Link>
-                    </h2>
+                      {/* Title */}
+                      <h2 className="text-lg font-bold text-gray-900 mb-3 line-clamp-2 hover:text-blue-600 transition-colors">
+                        <Link href={`/blog/${post.slug}`}>{post.title}</Link>
+                      </h2>
 
-                    {/* Excerpt */}
-                    <p className="text-gray-600 text-sm mb-4 line-clamp-2">{post.excerpt}</p>
+                      {/* Excerpt */}
+                      <p className="text-gray-600 text-sm mb-4 line-clamp-2">{post.excerpt}</p>
 
-                    {/* Tags */}
-                    <div className="flex flex-wrap gap-1 mb-4">
-                      {post.tags.slice(0, 3).map((t) => (
-                        <Link
-                          key={t}
-                          href={`/blog/tag/${t.toLowerCase().replace(/\s+/g, '-')}`}
-                          className={`text-xs px-2 py-0.5 rounded ${
-                            t.toLowerCase() === tag.toLowerCase()
-                              ? 'bg-purple-100 text-purple-700 font-medium'
-                              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-                          }`}
-                        >
-                          #{t}
-                        </Link>
-                      ))}
-                    </div>
+                      {/* Tags */}
+                      <div className="flex flex-wrap gap-1 mb-4">
+                        {post.tags.slice(0, 3).map((t) => (
+                          <Link
+                            key={t}
+                            href={`/blog/tag/${t.toLowerCase().replace(/\s+/g, '-')}`}
+                            className={`text-xs px-2 py-0.5 rounded ${
+                              t.toLowerCase() === tag.toLowerCase()
+                                ? 'bg-purple-100 text-purple-700 font-medium'
+                                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                            }`}
+                          >
+                            #{t}
+                          </Link>
+                        ))}
+                      </div>
 
-                    {/* Meta */}
-                    <div className="flex items-center justify-between text-xs text-gray-500 pt-4 border-t border-gray-100">
-                      <div className="flex items-center gap-3">
+                      {/* Meta */}
+                      <div className="flex items-center justify-between text-xs text-gray-500 pt-4 border-t border-gray-100">
+                        <div className="flex items-center gap-3">
+                          <span className="flex items-center">
+                            <Clock className="w-3 h-3 mr-1" />
+                            {post.readTime}m
+                          </span>
+                          <span className="flex items-center">
+                            <Eye className="w-3 h-3 mr-1" />
+                            {post.views?.toLocaleString()}
+                          </span>
+                        </div>
                         <span className="flex items-center">
-                          <Clock className="w-3 h-3 mr-1" />
-                          {post.readTime}m
-                        </span>
-                        <span className="flex items-center">
-                          <Eye className="w-3 h-3 mr-1" />
-                          {post.views?.toLocaleString()}
+                          <User className="w-3 h-3 mr-1" />
+                          {post.author.name}
                         </span>
                       </div>
-                      <span className="flex items-center">
-                        <User className="w-3 h-3 mr-1" />
-                        {post.author.name}
-                      </span>
                     </div>
-                  </div>
-                </article>
-              ))}
-            </div>
+                  </article>
+                ))}
+              </div>
+
+              <BlogPagination
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={handlePageChange}
+              />
+            </>
           )}
         </div>
       </section>


### PR DESCRIPTION
## Summary
- **Pagination + sorting** on CategoryArchivePage and TagArchivePage (9 posts/page, sort by newest/popular/quick reads)
- **Bookmark view** — clicking "X saved" now filters to bookmarked posts only, with active pill styling and filter chip
- **Popular Topics** section on main blog listing showing top 15 tags as clickable pills with count badges
- **Sticky category nav bar** across all `/blog/*` routes with active state highlighting and horizontal scroll on mobile
- 3 new SEO blog posts for high-value keyword gaps

## Test plan
- [ ] Verify pagination on category and tag archive pages (navigate pages, sort changes reset to page 1)
- [ ] Test bookmark toggle: bookmark posts, click "X saved" to filter, clear filters resets it
- [ ] Verify popular tags section renders with correct counts and links to tag archives
- [ ] Test sticky nav: scroll behavior, active state on `/blog`, `/blog/category/*`, and individual posts
- [ ] Responsive check at 375px (mobile), 768px (tablet), 1280px (desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)