### PR TITLE
fix: Immediate SEO actions - redirects, reviews, security.txt, ads.txt

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -284,6 +284,27 @@ const nextConfig = {
         destination: '/admin',
         permanent: true,
       },
+      // Fix 404 errors for common page variations
+      {
+        source: '/free-demo',
+        destination: '/book-free-demo',
+        permanent: true,
+      },
+      {
+        source: '/demo',
+        destination: '/book-free-demo',
+        permanent: true,
+      },
+      {
+        source: '/courses/neet-foundation',
+        destination: '/courses/foundation',
+        permanent: true,
+      },
+      {
+        source: '/neet-foundation',
+        destination: '/courses/foundation',
+        permanent: true,
+      },
       // Old blog slugs redirecting to relevant existing content
       {
         source: '/blog/neet-preparation-timeline-class-9-to-2028',

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,22 @@
+# Cerebrum Biology Academy Security Policy
+# https://cerebrumbiologyacademy.com/.well-known/security.txt
+
+Contact: mailto:security@cerebrumbiologyacademy.com
+Contact: mailto:bobbyaiims@gmail.com
+Expires: 2026-12-31T23:59:59.000Z
+Encryption: https://cerebrumbiologyacademy.com/pgp-key.txt
+Preferred-Languages: en, hi
+Canonical: https://cerebrumbiologyacademy.com/.well-known/security.txt
+
+# Policy
+# We take security seriously. If you discover a vulnerability,
+# please report it responsibly to the contacts above.
+# We appreciate your help in keeping our students' data safe.
+
+# Scope
+# This policy applies to:
+# - cerebrumbiologyacademy.com
+# - *.cerebrumbiologyacademy.com
+
+# Acknowledgments
+# We thank security researchers who help us improve our security.

--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,14 @@
+# Cerebrum Biology Academy - Authorized Digital Sellers (ads.txt)
+# https://cerebrumbiologyacademy.com/ads.txt
+#
+# This file declares authorized sellers of our digital advertising inventory.
+# For more information, see: https://iabtechlab.com/ads-txt/
+#
+# Format: <domain>, <publisher_id>, <relationship>, <certification_authority_id>
+
+# Google AdSense (if applicable - replace with actual publisher ID)
+# google.com, pub-XXXXXXXXXXXXXXXX, DIRECT, f08c47fec0942fa0
+
+# Currently, Cerebrum Biology Academy does not participate in programmatic advertising.
+# This ads.txt file is provided for transparency purposes.
+# Contact: bobbyaiims@gmail.com for advertising inquiries.

--- a/public/security.txt
+++ b/public/security.txt
@@ -1,0 +1,8 @@
+# Cerebrum Biology Academy Security Policy
+# Canonical location: https://cerebrumbiologyacademy.com/.well-known/security.txt
+
+Contact: mailto:security@cerebrumbiologyacademy.com
+Contact: mailto:bobbyaiims@gmail.com
+Expires: 2026-12-31T23:59:59.000Z
+Preferred-Languages: en, hi
+Canonical: https://cerebrumbiologyacademy.com/.well-known/security.txt

--- a/src/components/seo/StructuredData.tsx
+++ b/src/components/seo/StructuredData.tsx
@@ -163,7 +163,7 @@ export function OrganizationSchema() {
     aggregateRating: {
       '@type': 'AggregateRating',
       ratingValue: '4.9',
-      reviewCount: '2500',
+      reviewCount: '500',
       bestRating: '5',
     },
   }
@@ -272,7 +272,7 @@ export function CourseSchema() {
     aggregateRating: {
       '@type': 'AggregateRating',
       ratingValue: '4.9',
-      reviewCount: '2500',
+      reviewCount: '500',
       bestRating: '5',
       worstRating: '1',
     },
@@ -722,7 +722,7 @@ export function NationalServiceSchema() {
     aggregateRating: {
       '@type': 'AggregateRating',
       ratingValue: '4.9',
-      reviewCount: '2500',
+      reviewCount: '500',
       bestRating: '5',
     },
     hasOfferCatalog: {


### PR DESCRIPTION
1. Add 404 fix redirects:
   - /free-demo → /book-free-demo
   - /demo → /book-free-demo
   - /courses/neet-foundation → /courses/foundation
   - /neet-foundation → /courses/foundation

2. Standardize review count:
   - Changed from 2500 to 500 (verifiable number)
   - Consistent across all schema.org structured data

3. Add security.txt (RFC 9116):
   - /.well-known/security.txt (canonical)
   - /security.txt (backwards compatibility)
   - Contact emails for vulnerability disclosure

4. Add ads.txt for advertising transparency:
   - IAB Tech Lab standard format
   - Currently indicates no programmatic advertising
   - Ready for future ad network integration