### PR TITLE
fix: Blog category nav overlapping header

### DIFF
--- a/src/components/blog/BlogCategoryNav.tsx
+++ b/src/components/blog/BlogCategoryNav.tsx
@@ -15,7 +15,7 @@ export function BlogCategoryNav() {
     : null
 
   return (
-    <nav className="sticky top-0 z-40 bg-white/95 backdrop-blur-md border-b border-gray-200 shadow-sm">
+    <nav className="sticky top-16 lg:top-20 z-40 bg-white/95 backdrop-blur-md border-b border-gray-200 shadow-sm">
       <div className="max-w-7xl mx-auto px-4">
         <div className="flex items-center gap-2 py-3 overflow-x-auto scrollbar-hide">
           <Link


### PR DESCRIPTION
Changed BlogCategoryNav sticky position from top-0 to top-16/top-20 to prevent it from overlapping with the main header when scrolling.