### PR TITLE
fix(seo): remove broken hreflang, global canonical, false sitemap dates

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -89,7 +89,6 @@ export const metadata: Metadata = {
     creator: '@cerebrumbiologyacademy',
   },
   alternates: {
-    canonical: 'https://cerebrumbiologyacademy.com',
     types: {
       'application/rss+xml': '/blog/feed.xml',
     },
@@ -98,21 +97,6 @@ export const metadata: Metadata = {
       'en-IN': 'https://cerebrumbiologyacademy.com',
       hi: 'https://cerebrumbiologyacademy.com/hi',
       'hi-IN': 'https://cerebrumbiologyacademy.com/hi',
-      bn: 'https://cerebrumbiologyacademy.com/bn',
-      ta: 'https://cerebrumbiologyacademy.com/ta',
-      te: 'https://cerebrumbiologyacademy.com/te',
-      mr: 'https://cerebrumbiologyacademy.com/mr',
-      kn: 'https://cerebrumbiologyacademy.com/kn',
-      ml: 'https://cerebrumbiologyacademy.com/ml',
-      de: 'https://cerebrumbiologyacademy.com/de',
-      es: 'https://cerebrumbiologyacademy.com/es',
-      fr: 'https://cerebrumbiologyacademy.com/fr',
-      it: 'https://cerebrumbiologyacademy.com/it',
-      ja: 'https://cerebrumbiologyacademy.com/ja',
-      nl: 'https://cerebrumbiologyacademy.com/nl',
-      pl: 'https://cerebrumbiologyacademy.com/pl',
-      pt: 'https://cerebrumbiologyacademy.com/pt',
-      ru: 'https://cerebrumbiologyacademy.com/ru',
       'x-default': 'https://cerebrumbiologyacademy.com',
     },
   },
@@ -173,26 +157,11 @@ export default function RootLayout({
         <meta httpEquiv="Content-Language" content="en-IN,hi-IN" />
         <meta name="language" content="English,Hindi" />
 
-        {/* Comprehensive hreflang tags for 17 languages + x-default */}
+        {/* hreflang tags — only languages with actual pages */}
         <link rel="alternate" hrefLang="en" href="https://cerebrumbiologyacademy.com" />
         <link rel="alternate" hrefLang="en-IN" href="https://cerebrumbiologyacademy.com" />
         <link rel="alternate" hrefLang="hi" href="https://cerebrumbiologyacademy.com/hi" />
         <link rel="alternate" hrefLang="hi-IN" href="https://cerebrumbiologyacademy.com/hi" />
-        <link rel="alternate" hrefLang="bn" href="https://cerebrumbiologyacademy.com/bn" />
-        <link rel="alternate" hrefLang="ta" href="https://cerebrumbiologyacademy.com/ta" />
-        <link rel="alternate" hrefLang="te" href="https://cerebrumbiologyacademy.com/te" />
-        <link rel="alternate" hrefLang="mr" href="https://cerebrumbiologyacademy.com/mr" />
-        <link rel="alternate" hrefLang="kn" href="https://cerebrumbiologyacademy.com/kn" />
-        <link rel="alternate" hrefLang="ml" href="https://cerebrumbiologyacademy.com/ml" />
-        <link rel="alternate" hrefLang="de" href="https://cerebrumbiologyacademy.com/de" />
-        <link rel="alternate" hrefLang="es" href="https://cerebrumbiologyacademy.com/es" />
-        <link rel="alternate" hrefLang="fr" href="https://cerebrumbiologyacademy.com/fr" />
-        <link rel="alternate" hrefLang="it" href="https://cerebrumbiologyacademy.com/it" />
-        <link rel="alternate" hrefLang="ja" href="https://cerebrumbiologyacademy.com/ja" />
-        <link rel="alternate" hrefLang="nl" href="https://cerebrumbiologyacademy.com/nl" />
-        <link rel="alternate" hrefLang="pl" href="https://cerebrumbiologyacademy.com/pl" />
-        <link rel="alternate" hrefLang="pt" href="https://cerebrumbiologyacademy.com/pt" />
-        <link rel="alternate" hrefLang="ru" href="https://cerebrumbiologyacademy.com/ru" />
         <link rel="alternate" hrefLang="x-default" href="https://cerebrumbiologyacademy.com" />
         <meta name="theme-color" content="#2563eb" />
         <meta name="mobile-web-app-capable" content="yes" />

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -6,9 +6,9 @@ import { getAllAreaSlugs } from '@/data/localAreas'
 export default function sitemap(): MetadataRoute.Sitemap {
   // Use non-www URL to match middleware redirect behavior
   const baseUrl = 'https://cerebrumbiologyacademy.com'
-  // Use build timestamp for static pages - reflects when site was last deployed
-  // This is better for SEO than a hard-coded date that doesn't reflect reality
-  const lastUpdated = new Date()
+  // Use a stable date for static pages so Google can distinguish actual content updates
+  // from mere redeployments. Update this date when site content meaningfully changes.
+  const lastUpdated = new Date('2026-02-06')
 
   // Dynamically generate blog post URLs from MDX files
   const blogPosts = getAllPosts()


### PR DESCRIPTION
## Summary
- Remove 15 broken hreflang tags pointing to non-existent language pages (only `/hi` exists, but `/bn`, `/ta`, `/de`, `/fr`, `/ja`, etc. were declared — all 404)
- Remove global canonical from root layout that was conflicting with page-level canonicals, causing Google to treat pages as homepage duplicates
- Replace sitemap `new Date()` with stable date so Google can distinguish real content updates from redeployments

## Why This Matters
These 3 issues compound to hurt organic rankings:
1. **Broken hreflang** → wasted crawl budget + trust erosion (15 of 17 hreflang URLs return 404)
2. **Global canonical conflict** → pages without explicit canonical appear as homepage duplicates
3. **False sitemap freshness** → every page looks "just updated" daily, Google stops trusting dates

## Test plan
- [ ] Verify only `en`, `en-IN`, `hi`, `hi-IN`, `x-default` hreflang tags render in page source
- [ ] Verify no global canonical on non-homepage pages (check view-source on `/courses`)
- [ ] Verify sitemap.xml shows stable `2026-02-06` date, not today's date
- [ ] Run Google Search Console URL inspection on 2-3 pages to confirm clean signals

🤖 Generated with [Claude Code](https://claude.com/claude-code)