### PR TITLE
feat: Phase 1 SEO — title fixes, meta descriptions, dropper page, redirects

### DIFF
--- a/src/app/book-free-demo/layout.tsx
+++ b/src/app/book-free-demo/layout.tsx
@@ -1,0 +1,7 @@
+import { generatePageMetadata } from '@/lib/seo/metadata'
+
+export const metadata = generatePageMetadata('bookDemo')
+
+export default function BookFreeDemoLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/src/app/neet-coaching-gurugram/layout.tsx
+++ b/src/app/neet-coaching-gurugram/layout.tsx
@@ -2,9 +2,9 @@ import type { Metadata } from 'next'
 import { LocalBusinessSchema } from '@/components/seo/LocalBusinessSchema'
 
 export const metadata: Metadata = {
-  title: 'Best NEET Coaching in Gurugram | DLF, Golf Course Road, Sector 51 | Cerebrum Academy',
+  title: 'Best NEET Coaching in Gurugram 2026 | DLF, Golf Course Road, Sector 51 | Cerebrum Academy',
   description:
-    'Top NEET biology coaching in Gurugram. 98% success rate, AIIMS faculty. Best coaching in DLF Phase 1-5, Golf Course Road, Sector 51 (Mayfield Garden), Sohna Road. 620+ students. Book free demo!',
+    'Top NEET biology coaching in Gurugram 2026. 98% success rate, AIIMS faculty, 15-student batches. Best coaching near DLF Phase 1-5, Golf Course Road, Sector 51, Sohna Road. 680+ students selected. Book free demo class!',
   keywords:
     'NEET coaching Gurugram, NEET coaching Gurgaon, NEET classes DLF, biology coaching Golf Course Road, NEET tuition Sector 51, NEET coaching Sohna Road, NEET coaching MG Road, best NEET coaching Gurugram, NEET preparation Gurgaon, online NEET coaching Gurugram, medical coaching Gurugram',
   openGraph: {

--- a/src/app/neet-dropper-batch/page.tsx
+++ b/src/app/neet-dropper-batch/page.tsx
@@ -1,0 +1,39 @@
+import { Metadata } from 'next'
+import { SEOLandingPage } from '@/components/seo-landing'
+import { dropperSEOPages } from '@/data/seo-landing'
+
+const content = dropperSEOPages.neetDropperBatch
+
+export const metadata: Metadata = {
+  title: content.title,
+  description: content.metaDescription,
+  keywords: content.keywords,
+  openGraph: {
+    title: content.title,
+    description: content.metaDescription,
+    type: 'website',
+    url: `https://cerebrumbiologyacademy.com/${content.slug}`,
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: content.title,
+    description: content.metaDescription,
+  },
+  alternates: {
+    canonical: `https://cerebrumbiologyacademy.com/${content.slug}`,
+  },
+}
+
+export default function NeetDropperBatchPage() {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(content.schema),
+        }}
+      />
+      <SEOLandingPage content={content} />
+    </>
+  )
+}

--- a/src/app/pricing/layout.tsx
+++ b/src/app/pricing/layout.tsx
@@ -1,0 +1,7 @@
+import { generatePageMetadata } from '@/lib/seo/metadata'
+
+export const metadata = generatePageMetadata('pricing')
+
+export default function PricingLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/src/app/results/layout.tsx
+++ b/src/app/results/layout.tsx
@@ -1,0 +1,7 @@
+import { generatePageMetadata } from '@/lib/seo/metadata'
+
+export const metadata = generatePageMetadata('results')
+
+export default function ResultsLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>
+}

--- a/src/components/seo/ConsistentNAP.tsx
+++ b/src/components/seo/ConsistentNAP.tsx
@@ -53,6 +53,12 @@ const BUSINESS_INFO = {
       phone: CONTACT_INFO.phone.formatted.primary,
       geo: { lat: '28.3870', lng: '77.3070' },
     },
+    {
+      name: 'Cerebrum Biology Academy - Noida',
+      address: 'B-45, Sector 62, Noida - 201301',
+      phone: CONTACT_INFO.phone.formatted.primary,
+      geo: { lat: '28.6280', lng: '77.3649' },
+    },
   ],
   openingHours: [
     {

--- a/src/config/seo-redirects.mjs
+++ b/src/config/seo-redirects.mjs
@@ -846,4 +846,18 @@ export const seoPageConsolidationRedirects = [
     destination: '/neet-coaching-west-delhi',
     permanent: true,
   },
+
+  // ============================================
+  // Batch 10: SEO URL Aliases → Canonical Pages
+  // ============================================
+  {
+    source: '/neet-coaching-comparison',
+    destination: '/compare/neet-coaching-comparison',
+    permanent: true,
+  },
+  {
+    source: '/testimonials',
+    destination: '/results',
+    permanent: true,
+  },
 ]

--- a/src/data/navigationConfig.ts
+++ b/src/data/navigationConfig.ts
@@ -202,10 +202,10 @@ export const navigationConfig: NavigationSection[] = [
     items: [
       {
         id: 'neet-results',
-        title: 'NEET Results 2025',
+        title: 'NEET Results 2026',
         href: '/company/results',
-        description: 'Our students\' NEET 2025 results and achievements',
-        keywords: ['neet results', 'results 2025', 'toppers', 'achievements'],
+        description: 'Our students\' NEET 2026 results and achievements',
+        keywords: ['neet results', 'results 2026', 'toppers', 'achievements'],
         isPopular: true,
       },
       {

--- a/src/data/seo-landing/dropper-content.ts
+++ b/src/data/seo-landing/dropper-content.ts
@@ -1014,8 +1014,167 @@ export const neetRepeaters2026: SEOLandingContent = {
   },
 }
 
+// Page: /neet-dropper-batch/ (Central Hub)
+export const neetDropperBatch: SEOLandingContent = {
+  ...dropperBaseContent,
+  slug: 'neet-dropper-batch',
+
+  title: 'NEET Dropper Batch 2026 Delhi NCR | Online & Offline | Cerebrum Academy',
+  metaDescription:
+    'NEET dropper batch 2026 by Cerebrum Academy. Online & offline in Delhi NCR — South Extension, Gurugram, Noida. AIIMS faculty, 15-student batches, 92% success rate. 80-120 marks avg improvement. Join now!',
+  keywords: [
+    'NEET dropper batch 2026',
+    'NEET dropper batch Delhi',
+    'NEET dropper course Delhi NCR',
+    'NEET repeater batch 2026',
+    'best NEET dropper coaching Delhi',
+    'NEET drop year coaching',
+    'NEET dropper batch near me',
+    'NEET dropper batch online',
+    'NEET dropper batch offline Delhi',
+    'NEET second attempt coaching',
+    'NEET dropper batch Gurugram',
+    'NEET dropper batch Noida',
+  ],
+
+  hero: {
+    headline: 'NEET Dropper Batch 2026 — Your Comeback Starts Here',
+    subheadline:
+      'Turn your drop year into a medical seat. Choose online or attend in person at our Delhi NCR centers. AIIMS faculty, 15-student batches, and a proven 92% success rate.',
+    highlightedText: '80-120 Marks Average Improvement',
+    ctaText: 'Join 2026 Dropper Batch',
+    ctaLink: '/enrollment',
+    backgroundGradient: 'from-red-900 via-orange-900 to-amber-900',
+  },
+
+  painPoints: {
+    title: 'We Know What You Are Going Through',
+    points: [
+      {
+        icon: 'refresh-cw',
+        question: 'Scored below your potential in NEET?',
+        solution:
+          'Most AIIMS toppers took 2 attempts. Our structured dropper program identifies exactly where you fell short and fixes it methodically.',
+      },
+      {
+        icon: 'map-pin',
+        question: 'Confused between online and offline coaching?',
+        solution:
+          'Choose what works for you — attend live classes at our South Extension, Gurugram or Noida centers, or study from home with our online batch. Same faculty, same results.',
+      },
+      {
+        icon: 'users',
+        question: 'Worried about large crowded batches?',
+        solution:
+          'Only 10-15 students per batch. Every doubt gets answered. Every student gets personal attention from Dr. Shekhar and the AIIMS faculty team.',
+      },
+      {
+        icon: 'target',
+        question: 'Not sure if a drop year is worth it?',
+        solution:
+          '1,200+ Cerebrum droppers have cracked NEET. Average improvement: 80-120 marks. The numbers speak for themselves.',
+      },
+    ],
+  },
+
+  benefits: {
+    title: 'Why Cerebrum Dropper Batch Works',
+    subtitle: 'A focused year designed around how droppers actually need to study',
+    items: [
+      {
+        icon: 'search',
+        title: 'Diagnostic Gap Analysis',
+        description: 'Day-one assessment pinpoints weak chapters. Your study plan is built around YOUR gaps, not a generic syllabus.',
+      },
+      {
+        icon: 'map-pin',
+        title: 'Online + Offline Flexibility',
+        description: 'Attend classes at South Extension, Gurugram or Noida centers or join the online batch. Switch modes anytime.',
+      },
+      {
+        icon: 'calendar',
+        title: 'Intensive 6-Day Schedule',
+        description: 'Complete Class 11 + 12 revision in a structured year-long program. No school distractions — 100% NEET focus.',
+      },
+      {
+        icon: 'bar-chart',
+        title: '50+ Full-Length Mock Tests',
+        description: 'Weekly NEET-pattern tests with detailed analysis. Track your improvement every single week.',
+      },
+      {
+        icon: 'heart',
+        title: 'Mental Wellness Support',
+        description: 'Drop year stress is real. Weekly motivation sessions, peer groups, and one-on-one counseling keep you on track.',
+      },
+      {
+        icon: 'user-check',
+        title: 'Personal Mentorship by Dr. Shekhar',
+        description: 'AIIMS alumnus Dr. Shekhar personally mentors every dropper student. Strategy calls, doubt sessions, and career guidance.',
+      },
+    ],
+  },
+
+  faqs: [
+    {
+      question: 'What is the NEET dropper batch fee at Cerebrum Academy?',
+      answer:
+        'The NEET dropper batch fee is Rs 80,000 per year (MRP Rs 95,000). This includes 6-day weekly classes, complete study material, 50+ mock tests, mental wellness support, and personal mentorship. EMI option available at Rs 4,500 per month. This is significantly more affordable than Aakash (Rs 1.36 lakh+) or Allen while offering smaller batches.',
+    },
+    {
+      question: 'Is the dropper batch available online and offline both?',
+      answer:
+        'Yes. You can attend classes in person at our South Extension (Delhi), Gurugram, or Noida centers, or join the fully online batch from anywhere in India. Both modes have the same AIIMS faculty, same curriculum, and same test series. Many students start offline and switch to online closer to the exam.',
+    },
+    {
+      question: 'How much can I improve my NEET score in a drop year?',
+      answer:
+        'Our dropper students improve by 80-120 marks on average. Many improve by 150+ marks. Rohit Mehta improved from 520 to 642 (AIIMS Delhi), Anjali Verma scored 618 and got MAMC Delhi. The key is structured preparation with gap analysis, not just repeating the same syllabus.',
+    },
+    {
+      question: 'Is taking a drop year for NEET worth it in 2026?',
+      answer:
+        'Absolutely, if done with the right guidance. Statistics show that many AIIMS and top medical college selections come from second-attempt students. Our dropper batch has a 92% success rate. The drop year is an investment — one year now for a 40-year medical career.',
+    },
+    {
+      question: 'What is the batch size for droppers at Cerebrum?',
+      answer:
+        'Only 10-15 students per batch. This is our biggest advantage over large coaching centers that pack 100+ students in a room. Every dropper gets personal attention, doubt resolution within minutes, and direct access to Dr. Shekhar for strategy sessions.',
+    },
+    {
+      question: 'When does the NEET 2026 dropper batch start?',
+      answer:
+        'New batches start in June and July every year, right after NEET results. We also have mid-year joining options for students who decide later. Early joiners get the full 12-month program advantage. Contact us on WhatsApp at +91-88264-44334 for the latest batch schedule.',
+    },
+  ],
+
+  cta: {
+    title: 'Your Drop Year. Your Comeback.',
+    subtitle: 'Join 1,200+ droppers who turned their second chance into AIIMS, JIPMER, and top medical colleges.',
+    primaryButton: {
+      text: 'Enroll in 2026 Dropper Batch',
+      link: '/enrollment',
+    },
+    secondaryButton: {
+      text: 'Book Free Counseling Session',
+      link: '/book-free-demo',
+    },
+  },
+
+  schema: {
+    '@type': 'Course',
+    courseName: 'NEET Dropper Batch 2026 - Online & Offline',
+    provider: 'Cerebrum Biology Academy',
+    description:
+      'Intensive NEET dropper batch with online and offline options across Delhi NCR. AIIMS faculty, 15-student batches, 92% success rate.',
+    duration: 'P12M',
+    price: 80000,
+    priceCurrency: 'INR',
+  },
+}
+
 // Export all Dropper content
 export const dropperSEOPages = {
+  neetDropperBatch,
   neetDropperBatchOnline,
   neetRepeaterCourse2025,
   neetDropperBiologyCoaching,

--- a/src/lib/seo/metadata.ts
+++ b/src/lib/seo/metadata.ts
@@ -25,7 +25,7 @@ export const pageMetadata: Record<string, PageMetadata> = {
     title:
       'Best NEET Biology Coaching in Delhi NCR | Laxmi Nagar, Dwarka, Noida, Gurgaon | Cerebrum Academy',
     description:
-      'Top NEET coaching in Delhi NCR - Laxmi Nagar, Dwarka, Noida, Gurgaon, Rohini, Pitampura. Expert AIIMS faculty, 98% success rate, small batches. Best biology coaching for Class 11, 12 & droppers. Book free demo!',
+      'Top NEET coaching in Delhi NCR 2026. AIIMS faculty, 98% success rate, 15-student batches, 680+ selections. 6 centers — South Extension, Green Park, Rohini, Gurugram, Noida, Faridabad. Class 11, 12 & droppers. Book free demo!',
     keywords: [
       'NEET coaching in Delhi',
       'NEET coaching Delhi NCR',
@@ -89,7 +89,7 @@ export const pageMetadata: Record<string, PageMetadata> = {
   courses: {
     title: 'NEET Biology Courses Delhi NCR | Class 11, 12, Dropper Batches | Cerebrum Academy',
     description:
-      'Complete NEET biology courses in Delhi NCR - Class 11, Class 12, Dropper batches. Expert AIIMS faculty in Laxmi Nagar, Dwarka, Noida, Gurgaon. Best NEET preparation with small batches. Enroll now!',
+      'NEET biology courses 2026 in Delhi NCR — Class 11, Class 12 & Dropper batches. AIIMS faculty, 15-student batches, 98% success rate. Rs 45K–1.56L with EMI. 6 centers across Delhi NCR. Enroll now!',
     keywords: [
       'NEET biology courses Delhi',
       'NEET biology syllabus',
@@ -144,7 +144,7 @@ export const pageMetadata: Record<string, PageMetadata> = {
   enrollment: {
     title: 'Enroll Now - NEET Biology Coaching Delhi NCR | Cerebrum Academy Admission',
     description:
-      'Enroll in best NEET biology coaching in Delhi NCR. Affordable fees, EMI options. Join students from Laxmi Nagar, Dwarka, Noida, Gurgaon. Limited seats for 2025-26 batch!',
+      'Enroll in best NEET biology coaching in Delhi NCR. Affordable fees, EMI options. Join students from Laxmi Nagar, Dwarka, Noida, Gurgaon. Limited seats for 2026-27 batch!',
     keywords: [
       'NEET enrollment Delhi',
       'biology course admission Delhi NCR',
@@ -157,19 +157,58 @@ export const pageMetadata: Record<string, PageMetadata> = {
     ],
     canonical: '/enrollment',
   },
-  pricing: {
-    title: 'NEET Coaching Fees Delhi NCR | Affordable Biology Coaching | Cerebrum Academy',
+  bookDemo: {
+    title: 'Book Free NEET Demo Class 2026 | WhatsApp Instant Booking | Cerebrum Academy Delhi NCR',
     description:
-      'Affordable NEET coaching fees in Delhi NCR. Compare pricing with Laxmi Nagar, Dwarka, Noida institutes. EMI options available. Best value NEET preparation.',
+      'Book your FREE NEET biology demo class at Cerebrum Academy. Experience 15-student batches, AIIMS faculty teaching. Instant WhatsApp confirmation. 6 centers across Delhi NCR — South Extension, Green Park, Rohini, Gurugram, Noida, Faridabad.',
+    keywords: [
+      'book free demo NEET coaching',
+      'free demo class biology Delhi',
+      'NEET coaching demo Delhi NCR',
+      'free trial class NEET',
+      'book NEET demo class',
+      'free biology class Delhi',
+      'try NEET coaching free',
+      'NEET demo class near me',
+      'free NEET coaching trial Delhi',
+      'Cerebrum Academy demo class',
+    ],
+    canonical: '/book-free-demo',
+  },
+  results: {
+    title: 'NEET Results 2026 | 98% Success Rate, 680+ Selections | Cerebrum Academy Delhi NCR',
+    description:
+      'Cerebrum Academy NEET results: 98% qualification rate, 680+ medical college selections, AIIMS & JIPMER toppers. Real student testimonials from Delhi, Noida, Gurugram. 15-student batches deliver results.',
+    keywords: [
+      'NEET results 2026 Cerebrum',
+      'NEET success stories Delhi',
+      'NEET toppers Delhi NCR',
+      '98 percent NEET success rate',
+      'AIIMS selections Delhi coaching',
+      'NEET coaching results',
+      'student testimonials NEET Delhi',
+      'best NEET results Delhi NCR',
+      'Cerebrum Academy results',
+    ],
+    canonical: '/results',
+  },
+  pricing: {
+    title: 'NEET Coaching Fees 2026 Delhi NCR | Rs 45K–1.56L | EMI Available | Cerebrum Academy',
+    description:
+      'NEET biology coaching fees starting Rs 45,000 in Delhi NCR. 15-student batches, AIIMS faculty, 98% success rate. Compare with Aakash & Allen. Flexible EMI options across 6 centers. Book free demo!',
     keywords: [
       'NEET course fees Delhi',
+      'NEET coaching fees 2026',
       'biology coaching cost Delhi NCR',
       'affordable NEET coaching Delhi',
       'NEET coaching fees comparison',
-      'cheap NEET coaching Delhi',
-      'EMI NEET course Delhi',
+      'NEET coaching EMI Delhi',
       'NEET fees Laxmi Nagar',
       'NEET fees Dwarka',
+      'NEET coaching fees Noida',
+      'NEET coaching fees Gurgaon',
+      'Cerebrum Academy fees',
+      'small batch NEET coaching fees',
     ],
     canonical: '/pricing',
   },
@@ -201,25 +240,28 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'online NEET test Delhi',
       'free mock test NEET Delhi',
       'NEET question paper practice',
-      'NEET test series 2025 Delhi',
+      'NEET test series 2026 Delhi',
     ],
     canonical: '/mock-tests',
   },
   testimonials: {
-    title: 'NEET Toppers Delhi NCR | Student Success Stories | Cerebrum Academy Results',
+    title: 'NEET Results 2026 | 98% Success Rate, 680+ Selections | Cerebrum Academy Delhi NCR',
     description:
-      'NEET toppers from Delhi NCR - Laxmi Nagar, Dwarka, Noida, Gurgaon students. 98% success rate. Read real testimonials from AIIMS, JIPMER selections.',
+      'Cerebrum Academy NEET results: 98% qualification rate, 680+ medical college selections, AIIMS & JIPMER toppers. Real student testimonials from Delhi, Noida, Gurugram. 15-student batches deliver results.',
     keywords: [
       'NEET success stories Delhi',
       'NEET toppers Delhi NCR',
+      'NEET results 2026',
       'student testimonials Delhi',
       'NEET results Delhi',
       'AIIMS selections Delhi',
       'NEET coaching results Delhi NCR',
       'student reviews Delhi',
       'NEET success rate Delhi',
+      'Cerebrum Academy results',
+      'NEET topper interviews',
     ],
-    canonical: '/testimonials',
+    canonical: '/results',
   },
   faculty: {
     title: 'Expert NEET Biology Faculty Delhi NCR | AIIMS Qualified Teachers | Cerebrum Academy',
@@ -310,7 +352,7 @@ export const pageMetadata: Record<string, PageMetadata> = {
     canonical: '/neet-foundation-course',
   },
   kotaVsOnline: {
-    title: 'Kota vs Online NEET Coaching 2025: Complete Comparison | Save ₹2.5L',
+    title: 'Kota vs Online NEET Coaching 2026: Complete Comparison | Save ₹2.5L',
     description:
       'Kota vs Online NEET coaching comparison: 85% vs 60% success rate, ₹2.5L+ savings, stay home safely. Data-driven analysis every parent must read before choosing. Mental health matters.',
     keywords: [
@@ -351,7 +393,7 @@ export const pageMetadata: Record<string, PageMetadata> = {
   },
   // PAN-INDIA SEO PAGES
   onlineNeetCoachingIndia: {
-    title: 'Best Online NEET Coaching in India 2025 | Pan-India Live Classes | Cerebrum Academy',
+    title: 'Best Online NEET Coaching in India 2026 | Pan-India Live Classes | Cerebrum Academy',
     description:
       'Best online NEET coaching in India. Live interactive classes, AIIMS trained faculty, 98% success rate. Join students from all states - Rajasthan, UP, Maharashtra, Karnataka, Tamil Nadu, Gujarat, Kerala. Book free demo!',
     keywords: [
@@ -373,7 +415,7 @@ export const pageMetadata: Record<string, PageMetadata> = {
     canonical: '/online-neet-coaching-india',
   },
   bestNeetCoachingIndia: {
-    title: 'Best NEET Coaching in India 2025 [Compare Top 10] | 98% Success',
+    title: 'Best NEET Coaching in India 2026 [Compare Top 10] | 98% Success',
     description:
       "Honest comparison of India's top NEET coaching. AIIMS-trained faculty, 2500+ selections, 98% success rate. Compare fees, results vs Kota, Allen. Book FREE demo today!",
     keywords: [
@@ -385,7 +427,7 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'best biology coaching india',
       'neet coaching india ranking',
       'best neet preparation india',
-      'neet 2025 coaching india',
+      'neet 2026 coaching india',
       'neet 2026 coaching india',
       'affordable neet coaching india',
       'neet coaching fees india',
@@ -433,7 +475,7 @@ export const pageMetadata: Record<string, PageMetadata> = {
   // GURUGRAM SEO PAGES
   neetCoachingGurugram: {
     title:
-      'Best NEET Coaching in Gurugram 2025 | DLF, Golf Course Road, Sushant Lok | Cerebrum Academy',
+      'Best NEET Coaching in Gurugram 2026 | DLF, Golf Course Road, Sushant Lok | Cerebrum Academy',
     description:
       'Best NEET coaching in Gurugram - DLF Phase 1-4, Golf Course Road, Sushant Lok, Sector 14, 43, 51, 56, 57, South City. AIIMS trained faculties, 98% success rate. No Delhi travel needed. Online live classes from home. Book free demo!',
     keywords: [
@@ -460,14 +502,14 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'neet classes gurugram',
       'neet institute gurugram',
       'neet tuition gurugram',
-      'neet 2025 coaching gurugram',
+      'neet 2026 coaching gurugram',
       'neet 2026 coaching gurugram',
     ],
     canonical: '/neet-coaching-gurugram',
   },
   // COACHING HUB PAGES
   neetCoachingKaluSarai: {
-    title: 'Best NEET Coaching in Kalu Sarai 2025 | Near IIT Delhi | Cerebrum Academy',
+    title: 'Best NEET Coaching in Kalu Sarai 2026 | Near IIT Delhi | Cerebrum Academy',
     description:
       "Best NEET coaching in Kalu Sarai, Delhi's premier coaching hub near IIT Delhi. AIIMS trained faculty, 98% success rate, small batches. Near Hauz Khas Metro. Book free demo!",
     keywords: [
@@ -484,13 +526,13 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'medical coaching kalu sarai',
       'neet preparation kalu sarai delhi',
       'best biology coaching kalu sarai',
-      'neet 2025 coaching kalu sarai',
+      'neet 2026 coaching kalu sarai',
     ],
     canonical: '/neet-coaching-kalu-sarai',
   },
   neetCoachingRajinderNagar: {
     title:
-      "Best NEET Coaching in Rajinder Nagar 2025 | India's Coaching Capital | Cerebrum Academy",
+      "Best NEET Coaching in Rajinder Nagar 2026 | India's Coaching Capital | Cerebrum Academy",
     description:
       "Best NEET coaching in Rajinder Nagar, India's most famous coaching destination. AIIMS trained faculty, 98% success rate. Near Rajiv Chowk & Karol Bagh Metro. Book free demo!",
     keywords: [
@@ -505,13 +547,13 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'medical coaching rajinder nagar',
       'neet preparation rajinder nagar delhi',
       'best biology coaching rajinder nagar',
-      'neet 2025 coaching rajinder nagar',
+      'neet 2026 coaching rajinder nagar',
     ],
     canonical: '/neet-coaching-rajinder-nagar',
   },
   neetCoachingMukherjeeNagar: {
     title:
-      "Best NEET Coaching in Mukherjee Nagar 2025 | North Delhi's Coaching Hub | Cerebrum Academy",
+      "Best NEET Coaching in Mukherjee Nagar 2026 | North Delhi's Coaching Hub | Cerebrum Academy",
     description:
       "Best NEET coaching in Mukherjee Nagar, North Delhi's coaching capital. AIIMS trained faculty, 98% success rate. Near GTB Nagar Metro. Online + offline classes. Book free demo!",
     keywords: [
@@ -525,12 +567,12 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'medical coaching mukherjee nagar',
       'neet preparation mukherjee nagar delhi',
       'best biology coaching mukherjee nagar',
-      'neet 2025 coaching mukherjee nagar',
+      'neet 2026 coaching mukherjee nagar',
     ],
     canonical: '/neet-coaching-mukherjee-nagar',
   },
   neetCoachingGtbNagar: {
-    title: 'Best NEET Coaching in GTB Nagar 2025 | Near Delhi University | Cerebrum Academy',
+    title: 'Best NEET Coaching in GTB Nagar 2026 | Near Delhi University | Cerebrum Academy',
     description:
       'Best NEET coaching in GTB Nagar, near Delhi University North Campus. AIIMS trained faculty, 98% success rate. Academic environment. Book free demo!',
     keywords: [
@@ -544,12 +586,12 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'medical coaching gtb nagar',
       'neet preparation gtb nagar delhi',
       'best biology coaching gtb nagar',
-      'neet 2025 coaching gtb nagar',
+      'neet 2026 coaching gtb nagar',
     ],
     canonical: '/neet-coaching-gtb-nagar',
   },
   neetCoachingLajpatNagar: {
-    title: 'Best NEET Coaching in Lajpat Nagar 2025 | South Delhi Hub | Cerebrum Academy',
+    title: 'Best NEET Coaching in Lajpat Nagar 2026 | South Delhi Hub | Cerebrum Academy',
     description:
       'Best NEET coaching in Lajpat Nagar, South Delhi. AIIMS trained faculty, 98% success rate. Excellent metro connectivity. Online + offline classes. Book free demo!',
     keywords: [
@@ -563,12 +605,12 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'medical coaching lajpat nagar',
       'neet preparation lajpat nagar delhi',
       'best biology coaching lajpat nagar',
-      'neet 2025 coaching lajpat nagar',
+      'neet 2026 coaching lajpat nagar',
     ],
     canonical: '/neet-coaching-lajpat-nagar',
   },
   neetCoachingJanakpuri: {
-    title: 'Best NEET Coaching in Janakpuri 2025 | West Delhi | Cerebrum Academy',
+    title: 'Best NEET Coaching in Janakpuri 2026 | West Delhi | Cerebrum Academy',
     description:
       'Best NEET coaching in Janakpuri, West Delhi. AIIMS trained faculty, 98% success rate. Near Janakpuri West Metro. Online + offline classes. Book free demo!',
     keywords: [
@@ -583,14 +625,14 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'medical coaching janakpuri',
       'neet preparation janakpuri delhi',
       'best biology coaching janakpuri',
-      'neet 2025 coaching janakpuri',
+      'neet 2026 coaching janakpuri',
     ],
     canonical: '/neet-coaching-janakpuri',
   },
   // DELHI REGIONAL PAGES
   neetCoachingNorthDelhi: {
     title:
-      'Best NEET Coaching in North Delhi 2025 | Rohini, Pitampura, Model Town | Cerebrum Academy',
+      'Best NEET Coaching in North Delhi 2026 | Rohini, Pitampura, Model Town | Cerebrum Academy',
     description:
       'Best NEET coaching in North Delhi - Rohini, Pitampura, Model Town, GTB Nagar, Mukherjee Nagar. AIIMS trained faculty, 98% success rate. Book free demo!',
     keywords: [
@@ -606,12 +648,12 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'medical coaching north delhi',
       'neet preparation north delhi',
       'best biology coaching north delhi',
-      'neet 2025 coaching north delhi',
+      'neet 2026 coaching north delhi',
     ],
     canonical: '/neet-coaching-north-delhi',
   },
   neetCoachingEastDelhi: {
-    title: 'Best NEET Coaching in East Delhi 2025 | Laxmi Nagar, Preet Vihar | Cerebrum Academy',
+    title: 'Best NEET Coaching in East Delhi 2026 | Laxmi Nagar, Preet Vihar | Cerebrum Academy',
     description:
       'Best NEET coaching in East Delhi - Laxmi Nagar, Preet Vihar, Mayur Vihar, IP Extension. AIIMS trained faculty, 98% success rate. Book free demo!',
     keywords: [
@@ -627,12 +669,12 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'medical coaching east delhi',
       'neet preparation east delhi',
       'best biology coaching east delhi',
-      'neet 2025 coaching east delhi',
+      'neet 2026 coaching east delhi',
     ],
     canonical: '/neet-coaching-east-delhi',
   },
   neetCoachingWestDelhi: {
-    title: 'Best NEET Coaching in West Delhi 2025 | Dwarka, Janakpuri, Rajouri | Cerebrum Academy',
+    title: 'Best NEET Coaching in West Delhi 2026 | Dwarka, Janakpuri, Rajouri | Cerebrum Academy',
     description:
       'Best NEET coaching in West Delhi - Dwarka, Janakpuri, Rajouri Garden, Uttam Nagar. AIIMS trained faculty, 98% success rate. Book free demo!',
     keywords: [
@@ -648,12 +690,12 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'medical coaching west delhi',
       'neet preparation west delhi',
       'best biology coaching west delhi',
-      'neet 2025 coaching west delhi',
+      'neet 2026 coaching west delhi',
     ],
     canonical: '/neet-coaching-west-delhi',
   },
   neetCoachingSouthDelhi: {
-    title: 'Best NEET Coaching in South Delhi 2025 | Kalu Sarai, Hauz Khas, GK | Cerebrum Academy',
+    title: 'Best NEET Coaching in South Delhi 2026 | Kalu Sarai, Hauz Khas, GK | Cerebrum Academy',
     description:
       'Best NEET coaching in South Delhi - Kalu Sarai, Hauz Khas, Greater Kailash, Saket. AIIMS trained faculty, 98% success rate. Book free demo!',
     keywords: [
@@ -669,13 +711,13 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'medical coaching south delhi',
       'neet preparation south delhi',
       'best biology coaching south delhi',
-      'neet 2025 coaching south delhi',
+      'neet 2026 coaching south delhi',
     ],
     canonical: '/neet-coaching-south-delhi',
   },
   // NCR CITY PAGES
   neetCoachingNoida: {
-    title: 'Best NEET Coaching in Noida 2025 | Sector 18, 62, 63 | Cerebrum Academy',
+    title: 'Best NEET Coaching in Noida 2026 | Sector 18, 62, 63 | Cerebrum Academy',
     description:
       'Best NEET coaching in Noida - Sector 18, 62, 63, 15, 16. AIIMS trained faculty, 98% success rate. Online + offline classes. Book free demo!',
     keywords: [
@@ -690,12 +732,12 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'medical coaching noida',
       'neet preparation noida',
       'best biology coaching noida',
-      'neet 2025 coaching noida',
+      'neet 2026 coaching noida',
     ],
     canonical: '/neet-coaching-noida',
   },
   neetCoachingGhaziabad: {
-    title: 'Best NEET Coaching in Ghaziabad 2025 | Indirapuram, Vaishali | Cerebrum Academy',
+    title: 'Best NEET Coaching in Ghaziabad 2026 | Indirapuram, Vaishali | Cerebrum Academy',
     description:
       'Best NEET coaching in Ghaziabad - Indirapuram, Vaishali, Vasundhara, Kaushambi. AIIMS trained faculty, 98% success rate. Book free demo!',
     keywords: [
@@ -710,12 +752,12 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'medical coaching ghaziabad',
       'neet preparation ghaziabad',
       'best biology coaching ghaziabad',
-      'neet 2025 coaching ghaziabad',
+      'neet 2026 coaching ghaziabad',
     ],
     canonical: '/neet-coaching-ghaziabad',
   },
   neetCoachingFaridabad: {
-    title: 'Best NEET Coaching in Faridabad 2025 | Sector 17 | Cerebrum Academy',
+    title: 'Best NEET Coaching in Faridabad 2026 | Sector 17 | Cerebrum Academy',
     description:
       'Best NEET coaching in Faridabad - Sector 17, NIT, Ballabhgarh. AIIMS trained faculty, 98% success rate. Online + offline classes. Book free demo!',
     keywords: [
@@ -730,12 +772,12 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'medical coaching faridabad',
       'neet preparation faridabad',
       'best biology coaching faridabad',
-      'neet 2025 coaching faridabad',
+      'neet 2026 coaching faridabad',
     ],
     canonical: '/neet-coaching-faridabad',
   },
   neetCoachingGurgaon: {
-    title: 'Best NEET Coaching in Gurgaon 2025 | DLF, Sector 14, 56 | Cerebrum Academy',
+    title: 'Best NEET Coaching in Gurgaon 2026 | DLF, Sector 14, 56 | Cerebrum Academy',
     description:
       'Best NEET coaching in Gurgaon - DLF, Sector 14, 56, 57, Golf Course Road. AIIMS trained faculty, 98% success rate. Book free demo!',
     keywords: [
@@ -750,12 +792,12 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'medical coaching gurgaon',
       'neet preparation gurgaon',
       'best biology coaching gurgaon',
-      'neet 2025 coaching gurgaon',
+      'neet 2026 coaching gurgaon',
     ],
     canonical: '/neet-coaching-gurgaon',
   },
   neetCoachingGreaterNoidaWest: {
-    title: 'Best NEET Coaching in Greater Noida West 2025 | Noida Extension | Cerebrum Academy',
+    title: 'Best NEET Coaching in Greater Noida West 2026 | Noida Extension | Cerebrum Academy',
     description:
       'Best NEET coaching in Greater Noida West (Noida Extension). AIIMS trained faculty, 98% success rate. Online + offline classes. Book free demo!',
     keywords: [
@@ -768,13 +810,13 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'medical coaching greater noida west',
       'neet preparation greater noida west',
       'best biology coaching noida extension',
-      'neet 2025 coaching greater noida west',
+      'neet 2026 coaching greater noida west',
     ],
     canonical: '/neet-coaching-greater-noida-west',
   },
   // TIER-1 CITY PAGES
   neetCoachingMumbai: {
-    title: 'Best NEET Coaching in Mumbai 2025 | Andheri, Dadar, Thane | Cerebrum Academy',
+    title: 'Best NEET Coaching in Mumbai 2026 | Andheri, Dadar, Thane | Cerebrum Academy',
     description:
       'Best NEET coaching in Mumbai - Andheri, Dadar, Borivali, Thane, Navi Mumbai. AIIMS trained faculty, 98% success rate. Online + offline classes. Book free demo!',
     keywords: [
@@ -790,7 +832,7 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'medical coaching mumbai',
       'neet preparation mumbai',
       'best biology coaching mumbai',
-      'neet 2025 coaching mumbai',
+      'neet 2026 coaching mumbai',
       'biology tuition mumbai',
       'online biology coaching mumbai',
       'biology classes mumbai',
@@ -800,7 +842,7 @@ export const pageMetadata: Record<string, PageMetadata> = {
     canonical: '/neet-coaching-mumbai',
   },
   neetCoachingBangalore: {
-    title: 'Best NEET Coaching in Bangalore 2025 | Koramangala, HSR, Jayanagar | Cerebrum Academy',
+    title: 'Best NEET Coaching in Bangalore 2026 | Koramangala, HSR, Jayanagar | Cerebrum Academy',
     description:
       'Best NEET coaching in Bangalore - Koramangala, HSR Layout, Jayanagar, Indiranagar. AIIMS trained faculty, 98% success rate. Online + offline classes. Book free demo!',
     keywords: [
@@ -815,7 +857,7 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'medical coaching bangalore',
       'neet preparation bangalore',
       'best biology coaching bangalore',
-      'neet 2025 coaching bangalore',
+      'neet 2026 coaching bangalore',
       'biology tuition bangalore',
       'online biology coaching bangalore',
       'biology classes bangalore',
@@ -825,7 +867,7 @@ export const pageMetadata: Record<string, PageMetadata> = {
     canonical: '/neet-coaching-bangalore',
   },
   neetCoachingHyderabad: {
-    title: 'Best NEET Coaching in Hyderabad 2025 | KPHB, Ameerpet, Dilsukhnagar | Cerebrum Academy',
+    title: 'Best NEET Coaching in Hyderabad 2026 | KPHB, Ameerpet, Dilsukhnagar | Cerebrum Academy',
     description:
       'Best NEET coaching in Hyderabad - KPHB, Ameerpet, Dilsukhnagar, Secunderabad. AIIMS trained faculty, 98% success rate. Online + offline classes. Book free demo!',
     keywords: [
@@ -840,7 +882,7 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'medical coaching hyderabad',
       'neet preparation hyderabad',
       'best biology coaching hyderabad',
-      'neet 2025 coaching hyderabad',
+      'neet 2026 coaching hyderabad',
       'biology tuition hyderabad',
       'online biology coaching hyderabad',
       'biology classes hyderabad',
@@ -850,7 +892,7 @@ export const pageMetadata: Record<string, PageMetadata> = {
     canonical: '/neet-coaching-hyderabad',
   },
   neetCoachingChennai: {
-    title: 'Best NEET Coaching in Chennai 2025 | Anna Nagar, T Nagar, Velachery | Cerebrum Academy',
+    title: 'Best NEET Coaching in Chennai 2026 | Anna Nagar, T Nagar, Velachery | Cerebrum Academy',
     description:
       'Best NEET coaching in Chennai - Anna Nagar, T Nagar, Velachery, Tambaram. AIIMS trained faculty, 98% success rate. Online + offline classes. Book free demo!',
     keywords: [
@@ -865,7 +907,7 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'medical coaching chennai',
       'neet preparation chennai',
       'best biology coaching chennai',
-      'neet 2025 coaching chennai',
+      'neet 2026 coaching chennai',
       'biology tuition chennai',
       'online biology coaching chennai',
       'biology classes chennai',
@@ -875,7 +917,7 @@ export const pageMetadata: Record<string, PageMetadata> = {
     canonical: '/neet-coaching-chennai',
   },
   neetCoachingPune: {
-    title: 'Best NEET Coaching in Pune 2025 | Kothrud, Hinjewadi, FC Road | Cerebrum Academy',
+    title: 'Best NEET Coaching in Pune 2026 | Kothrud, Hinjewadi, FC Road | Cerebrum Academy',
     description:
       'Best NEET coaching in Pune - Kothrud, Hinjewadi, FC Road, Deccan. AIIMS trained faculty, 98% success rate. Online + offline classes. Book free demo!',
     keywords: [
@@ -890,7 +932,7 @@ export const pageMetadata: Record<string, PageMetadata> = {
       'medical coaching pune',
       'neet preparation pune',
       'best biology coaching pune',
-      'neet 2025 coaching pune',
+      'neet 2026 coaching pune',
       'biology tuition pune',
       'online biology coaching pune',
       'biology classes pune',


### PR DESCRIPTION
## Summary

Phase 1 Week 1 implementation of the Delhi NCR SEO/AEO/GEO strategy (per the 14-page implementation plan).

### Changes (10 files, +343/-62 lines)

**Title Tag Fixes (2025 to 2026)**
- Updated 25+ location page titles across metadata.ts — North Delhi, East Delhi, West Delhi, South Delhi, Noida, Ghaziabad, Faridabad, Greater Noida West, Mumbai, Bangalore, Hyderabad, Chennai, Pune, Gurugram, Gurgaon
- Updated Gurugram layout.tsx with 2026, 15-student batches, 680+ selections
- Fixed navigation config NEET Results 2025 to 2026

**Meta Descriptions (3 Critical Pages)**
- Created layout.tsx for /pricing, /results, /book-free-demo — all previously had NO custom metadata
- Added bookDemo and results entries to centralized metadata.ts
- Enhanced descriptions for home, courses, pricing, testimonials with USPs (98% success, 15-student batches, 680+ selections, Rs 45K-1.56L, EMI)

**New Page: /neet-dropper-batch**
- Central hub page for all dropper batch content (was missing — only city-specific variants existed)
- Full SEO content: title, meta, keywords, hero, pain points, benefits, FAQs, CTA, Course schema
- Covers online + offline options across Delhi NCR centers

**Infrastructure Fixes**
- Added Noida center to ConsistentNAP.tsx schema (was missing from 6-center list)
- Added /neet-coaching-comparison redirect to /compare/neet-coaching-comparison
- Added /testimonials redirect to /results

## Test plan
- [ ] Verify Vercel build succeeds
- [ ] Check /pricing page has custom title/description in page source
- [ ] Check /results page has custom title/description
- [ ] Check /book-free-demo page has custom title/description
- [ ] Check /neet-dropper-batch page renders correctly
- [ ] Verify /neet-coaching-comparison redirects to /compare/neet-coaching-comparison
- [ ] Verify all location page titles show 2026 instead of 2025
- [ ] Run Google Rich Results Test on key pages