### PR TITLE
fix: resolve 3 build-breaking errors in MVP Build Check

### DIFF
--- a/content/blog/class-11-biology-neet-complete-foundation.mdx
+++ b/content/blog/class-11-biology-neet-complete-foundation.mdx
@@ -1,13 +1,15 @@
 ---
 title: "Class 11 Biology for NEET 2026: Complete Foundation Building Strategy"
-description: "Build an unshakeable NEET Biology foundation in Class 11. Chapter-wise strategy for Botany and Zoology with NCERT mastery tips from Cerebrum Biology Academy."
-date: "2026-02-09"
-author: "Dr. Shekhar C Singh"
+excerpt: "Build an unshakeable NEET Biology foundation in Class 11. Chapter-wise strategy for Botany and Zoology with NCERT mastery tips from Cerebrum Biology Academy."
+publishedAt: "2026-02-09"
+author:
+  name: "Dr. Shekhar C Singh"
+  role: "Founder & Senior Faculty, Cerebrum Biology Academy"
 tags: ["class 11 biology", "neet foundation", "class 11 neet", "biology class 11", "neet preparation class 11"]
 category: "Study Strategy"
-readingTime: "11 min read"
+readTime: 11
 featured: false
-image: "/blog/placeholder.webp"
+featuredImage: "/blog/placeholder.webp"
 slug: "class-11-biology-neet-complete-foundation"
 ---
 

--- a/content/blog/future-of-neet-coaching-india-2026-expert-analysis.mdx
+++ b/content/blog/future-of-neet-coaching-india-2026-expert-analysis.mdx
@@ -13,7 +13,7 @@ updatedAt: '2026-02-09'
 readTime: 9
 isPublished: true
 seoTitle: 'Future of NEET Coaching India 2026-2030: Expert Trends & Predictions'
-seoDescription: 'Expert analysis by Dr. Shekhar C Singh on future of NEET coaching: AI, hybrid learning, small batches, regional expansion, outcome-based pricing. What's next in medical entrance prep.'
+seoDescription: "Expert analysis by Dr. Shekhar C Singh on future of NEET coaching: AI, hybrid learning, small batches, regional expansion, outcome-based pricing. What's next in medical entrance prep."
 difficulty: 'Intermediate'
 neetWeightage: 'High'
 targetAudience: 'Parent,Student,Educator,Industry'

--- a/content/blog/neet-2026-month-by-month-roadmap-complete.mdx
+++ b/content/blog/neet-2026-month-by-month-roadmap-complete.mdx
@@ -1,13 +1,15 @@
 ---
 title: "NEET 2026 Month-by-Month Roadmap: 12-Month Complete Preparation Plan"
-description: "Complete month-by-month NEET 2026 preparation roadmap from Dr. Shekhar Singh. Covers February to December with chapter targets, revision cycles, and mock test schedule."
-date: "2026-02-09"
-author: "Dr. Shekhar C Singh"
+excerpt: "Complete month-by-month NEET 2026 preparation roadmap from Dr. Shekhar Singh. Covers February to December with chapter targets, revision cycles, and mock test schedule."
+publishedAt: "2026-02-09"
+author:
+  name: "Dr. Shekhar C Singh"
+  role: "Founder & Senior Faculty, Cerebrum Biology Academy"
 tags: ["neet 2026 roadmap", "month by month plan", "neet preparation plan", "study schedule", "neet timetable"]
 category: "Study Strategy"
-readingTime: "14 min read"
+readTime: 14
 featured: true
-image: "/blog/placeholder.webp"
+featuredImage: "/blog/placeholder.webp"
 slug: "neet-2026-month-by-month-roadmap-complete"
 ---
 

--- a/content/blog/neet-biology-mcq-practice-guide-1000-questions.mdx
+++ b/content/blog/neet-biology-mcq-practice-guide-1000-questions.mdx
@@ -1,13 +1,15 @@
 ---
 title: "NEET Biology MCQ Practice 2026: Ultimate Guide to 1000+ Questions Strategy"
-description: "Master NEET Biology with our proven MCQ practice strategy. Learn chapter-wise question distribution, time management for 90 MCQs, common traps, and practice resources."
-date: "2026-02-09"
-author: "Dr. Shekhar C Singh"
+excerpt: "Master NEET Biology with our proven MCQ practice strategy. Learn chapter-wise question distribution, time management for 90 MCQs, common traps, and practice resources."
+publishedAt: "2026-02-09"
+author:
+  name: "Dr. Shekhar C Singh"
+  role: "Founder & Senior Faculty, Cerebrum Biology Academy"
 tags: ["neet biology mcq", "practice questions", "neet preparation", "biology practice", "mcq strategy"]
 category: "Study Strategy"
-readingTime: "11 min read"
+readTime: 11
 featured: false
-image: "/blog/placeholder.webp"
+featuredImage: "/blog/placeholder.webp"
 slug: "neet-biology-mcq-practice-guide-1000-questions"
 ---
 

--- a/content/blog/parents-guide-choosing-neet-coaching-delhi.mdx
+++ b/content/blog/parents-guide-choosing-neet-coaching-delhi.mdx
@@ -18,7 +18,7 @@ difficulty: 'Beginner'
 neetWeightage: 'High'
 targetAudience: 'Parent'
 keyTakeaways:
-  - 'Faculty credentials matter more than institute brand; verify previous students\' scores directly'
+  - "Faculty credentials matter more than institute brand; verify previous students' scores directly"
   - 'Batch sizes 30-80 are optimal; larger than 150 indicates impersonal teaching'
   - 'Average Delhi coaching: 3-5 lakhs; compare per-hour teaching cost, not total fee'
   - 'Red flags: High-pressure sales, guaranteed results, expensive add-ons, no trial classes'

--- a/content/blog/parents-guide-choosing-neet-coaching-delhi.mdx
+++ b/content/blog/parents-guide-choosing-neet-coaching-delhi.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Parent's Guide to Choosing NEET Coaching in Delhi — What to Check Before Paying'
+title: "Parent's Guide to Choosing NEET Coaching in Delhi — What to Check Before Paying"
 slug: parents-guide-choosing-neet-coaching-delhi
 excerpt: 'Complete guide for parents: what to look for in NEET coaching centers in Delhi, red flags, fee structures, EMI, trial classes, and verification checklist.'
 author:
@@ -12,7 +12,7 @@ publishedAt: '2026-02-09'
 updatedAt: '2026-02-09'
 readTime: 14
 isPublished: true
-seoTitle: 'Parent\'s Guide to Choosing NEET Coaching in Delhi | Verification Checklist'
+seoTitle: "Parent's Guide to Choosing NEET Coaching in Delhi | Verification Checklist"
 seoDescription: 'How to choose NEET coaching for your child in Delhi: faculty credentials, batch size, fees, EMI, and red flags.'
 difficulty: 'Beginner'
 neetWeightage: 'High'

--- a/src/app/about-cerebrum-biology-academy/page.tsx
+++ b/src/app/about-cerebrum-biology-academy/page.tsx
@@ -1,6 +1,4 @@
-'use client'
-
-import { Metadata } from 'next'
+import type { Metadata } from 'next'
 import {
   MapPin,
   Users,
@@ -46,7 +44,7 @@ const aboutFaqs = [
   },
 ]
 
-const metadata = {
+export const metadata: Metadata = {
   title: 'About Cerebrum Biology Academy — NEET Biology Coaching Since 2014 | Delhi NCR',
   description:
     "Cerebrum Biology Academy: India's premier NEET Biology coaching with AIIMS-trained faculty, 6 centers in Delhi NCR, 680+ selections, 94% success rate, batches of 8-15 students.",
@@ -69,8 +67,6 @@ const metadata = {
     canonical: 'https://cerebrumbiologyacademy.com/about-cerebrum-biology-academy',
   },
 }
-
-export { metadata }
 
 export default function AboutCerebrumPage() {
   const centers = [

--- a/src/app/neet-coaching-faq/page.tsx
+++ b/src/app/neet-coaching-faq/page.tsx
@@ -1,6 +1,4 @@
-'use client'
-
-import { Metadata } from 'next'
+import type { Metadata } from 'next'
 import { Phone, Mail, MessageCircle, ChevronDown } from 'lucide-react'
 import Link from 'next/link'
 import { BreadcrumbSchema } from '@/components/seo/BreadcrumbSchema'
@@ -301,8 +299,7 @@ const allFaqs = [
   ...faqData.studyTips,
 ]
 
-// Note: Metadata needs to be exported separately for server component
-const metadata = {
+export const metadata: Metadata = {
   title:
     'NEET Coaching FAQ 2026: 50+ Questions Answered | Cerebrum Biology Academy',
   description:
@@ -328,8 +325,6 @@ const metadata = {
     canonical: 'https://cerebrumbiologyacademy.com/neet-coaching-faq',
   },
 }
-
-export { metadata }
 
 export default function NEETCoachingFAQPage() {
   return (

--- a/src/components/seo/index.ts
+++ b/src/components/seo/index.ts
@@ -51,7 +51,7 @@ export {
   HowToSchema,
   PersonSchema,
   DrShekharSinghSchema,
-  VideoSchema as VideoObjectSchema,
+  VideoSchema as StructuredDataVideoSchema,
   ReviewSchema,
   ReviewListSchema,
   StructuredData,

--- a/src/lib/blog/mdx.ts
+++ b/src/lib/blog/mdx.ts
@@ -149,21 +149,23 @@ export function getPostBySlug(slug: string): {
   const meta: BlogPostMeta = {
     title: data.title || '',
     slug: data.slug || slug,
-    excerpt: data.excerpt || '',
-    author: data.author || { name: 'Cerebrum Biology Academy', role: 'Editorial Team' },
+    excerpt: data.excerpt || data.description || '',
+    author: typeof data.author === 'string'
+      ? { name: data.author, role: 'Faculty' }
+      : data.author || { name: 'Cerebrum Biology Academy', role: 'Editorial Team' },
     category: data.category || 'neet-preparation',
     tags: data.tags || [],
-    featuredImage: data.featuredImage || '/blog/default-featured.jpg',
-    publishedAt: data.publishedAt || new Date().toISOString(),
-    updatedAt: data.updatedAt || data.publishedAt || new Date().toISOString(),
-    readTime: parseReadTime(data.readTime) || Math.ceil(stats.minutes),
+    featuredImage: data.featuredImage || data.image || '/blog/default-featured.jpg',
+    publishedAt: data.publishedAt || data.date || new Date().toISOString(),
+    updatedAt: data.updatedAt || data.publishedAt || data.date || new Date().toISOString(),
+    readTime: parseReadTime(data.readTime || data.readingTime) || Math.ceil(stats.minutes),
     isPublished: data.isPublished !== false,
     seoTitle: data.seoTitle || data.title,
-    seoDescription: data.seoDescription || data.excerpt,
+    seoDescription: data.seoDescription || data.excerpt || data.description || '',
     views: generateViralBaseViews(
       slug,
       data.category || 'neet-preparation',
-      data.publishedAt || new Date().toISOString()
+      data.publishedAt || data.date || new Date().toISOString()
     ),
     difficulty: data.difficulty,
     neetChapter: data.neetChapter,


### PR DESCRIPTION
## Summary

Fixes 3 critical build-breaking errors that have been causing every MVP Build Check to fail since PR #27.

**Issue 1: Duplicate export in SEO barrel file**
- `src/components/seo/index.ts` exported `VideoObjectSchema` twice (line 54 as alias from StructuredData + line 181 from VideoObjectSchema.tsx)
- Fix: Renamed the alias to `StructuredDataVideoSchema`

**Issue 2: Invalid 'use client' + metadata export**
- `neet-coaching-faq/page.tsx` and `about-cerebrum-biology-academy/page.tsx` had `'use client'` but also exported `metadata` — not allowed in Next.js 15
- Fix: Removed `'use client'` (neither page uses hooks/events), properly typed `export const metadata: Metadata`

**Issue 3: YAML frontmatter apostrophe**
- `parents-guide-choosing-neet-coaching-delhi.mdx` had unescaped apostrophe in single-quoted title and invalid backslash escape in seoTitle
- Fix: Switched to double-quoted strings

## Test Plan

- [ ] MVP Build Check passes (this was the recurring failure)
- [ ] Verify FAQ page renders correctly
- [ ] Verify About page renders correctly
- [ ] Verify blog post parses correctly

Generated with [Claude Code](https://claude.com/claude-code)