### PR TITLE
fix: block crawl-waste URLs in robots.ts to reduce noindex pages

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -21,6 +21,12 @@ export default function robots(): MetadataRoute.Robots {
           '/ai-features/',
           '/enrollments/',
           '/boards/',
+          '/portal/',
+          '/counselor/',
+          // Block query parameter crawl waste (search, filters, etc.)
+          '/blog?',
+          '/courses?',
+          '/tools/',
           // Block phantom locale paths that have no real pages (only /hi and /ta exist)
           '/de/',
           '/es/',


### PR DESCRIPTION
Block URLs Google is wasting crawl budget on: /blog?search=, /courses?class=, /tools/, /portal/, /counselor/. These are already noindex via middleware but blocking in robots.txt saves crawl budget entirely.