### PR TITLE
fix: canonical tags + CSS crawl waste + query param blocking

### DIFF
--- a/src/app/dropper/layout.tsx
+++ b/src/app/dropper/layout.tsx
@@ -12,6 +12,9 @@ export const metadata: Metadata = {
     'NEET second attempt',
     'best coaching for NEET repeaters',
   ],
+  alternates: {
+    canonical: 'https://cerebrumbiologyacademy.com/dropper',
+  },
   openGraph: {
     title: 'NEET Dropper Course 2025 | Best Biology Coaching for Repeaters',
     description:

--- a/src/app/locations/anand-niketan/layout.tsx
+++ b/src/app/locations/anand-niketan/layout.tsx
@@ -15,6 +15,9 @@ export const metadata: Metadata = {
     'Biology tutor Anand Niketan',
     'NEET coaching Chanakyapuri area',
   ],
+  alternates: {
+    canonical: 'https://cerebrumbiologyacademy.com/locations/anand-niketan',
+  },
   openGraph: {
     title: 'NEET Biology Coaching Anand Niketan | Cerebrum Academy',
     description:

--- a/src/app/locations/cr-park/layout.tsx
+++ b/src/app/locations/cr-park/layout.tsx
@@ -18,6 +18,9 @@ export const metadata: Metadata = {
     'NEET coaching Alaknanda',
     'Biology classes Kalkaji',
   ],
+  alternates: {
+    canonical: 'https://cerebrumbiologyacademy.com/locations/cr-park',
+  },
   openGraph: {
     title: 'NEET Biology Coaching CR Park | Cerebrum Academy',
     description:

--- a/src/app/locations/golf-links/layout.tsx
+++ b/src/app/locations/golf-links/layout.tsx
@@ -18,6 +18,9 @@ export const metadata: Metadata = {
     'Elite NEET coaching Delhi',
     'NEET Biology coaching fees Delhi',
   ],
+  alternates: {
+    canonical: 'https://cerebrumbiologyacademy.com/locations/golf-links',
+  },
   openGraph: {
     title: 'NEET Biology Coaching Golf Links | Cerebrum Academy',
     description:

--- a/src/app/locations/jor-bagh/layout.tsx
+++ b/src/app/locations/jor-bagh/layout.tsx
@@ -16,6 +16,9 @@ export const metadata: Metadata = {
     'NEET Biology coaching Central Delhi',
     'Premium NEET coaching Delhi',
   ],
+  alternates: {
+    canonical: 'https://cerebrumbiologyacademy.com/locations/jor-bagh',
+  },
   openGraph: {
     title: 'NEET Biology Coaching Jor Bagh | Cerebrum Academy',
     description:

--- a/src/app/locations/kalkaji/layout.tsx
+++ b/src/app/locations/kalkaji/layout.tsx
@@ -17,6 +17,9 @@ export const metadata: Metadata = {
     'Biology classes Nehru Place',
     'NEET coaching Okhla',
   ],
+  alternates: {
+    canonical: 'https://cerebrumbiologyacademy.com/locations/kalkaji',
+  },
   openGraph: {
     title: 'NEET Biology Coaching Kalkaji | Cerebrum Academy',
     description:

--- a/src/app/locations/lajpat-nagar/layout.tsx
+++ b/src/app/locations/lajpat-nagar/layout.tsx
@@ -18,6 +18,9 @@ export const metadata: Metadata = {
     'NEET Biology coaching fees Delhi',
     'Best NEET coaching near me',
   ],
+  alternates: {
+    canonical: 'https://cerebrumbiologyacademy.com/locations/lajpat-nagar',
+  },
   openGraph: {
     title: 'NEET Biology Coaching Lajpat Nagar | Cerebrum Academy',
     description:

--- a/src/app/locations/malviya-nagar/layout.tsx
+++ b/src/app/locations/malviya-nagar/layout.tsx
@@ -18,6 +18,9 @@ export const metadata: Metadata = {
     'NEET Biology coaching fees Delhi',
     'Affordable NEET coaching Delhi',
   ],
+  alternates: {
+    canonical: 'https://cerebrumbiologyacademy.com/locations/malviya-nagar',
+  },
   openGraph: {
     title: 'NEET Biology Coaching Malviya Nagar | Cerebrum Academy',
     description:

--- a/src/app/locations/saket/layout.tsx
+++ b/src/app/locations/saket/layout.tsx
@@ -18,6 +18,9 @@ export const metadata: Metadata = {
     'NEET Biology coaching South Delhi',
     'Medical coaching Saket',
   ],
+  alternates: {
+    canonical: 'https://cerebrumbiologyacademy.com/locations/saket',
+  },
   openGraph: {
     title: 'NEET Biology Coaching Saket | Cerebrum Academy',
     description:

--- a/src/app/locations/shanti-niketan/layout.tsx
+++ b/src/app/locations/shanti-niketan/layout.tsx
@@ -16,6 +16,9 @@ export const metadata: Metadata = {
     'NEET coaching Diplomatic Enclave',
     'Biology classes West Delhi premium',
   ],
+  alternates: {
+    canonical: 'https://cerebrumbiologyacademy.com/locations/shanti-niketan',
+  },
   openGraph: {
     title: 'NEET Biology Coaching Shanti Niketan | Cerebrum Academy',
     description:

--- a/src/app/locations/sundar-nagar/layout.tsx
+++ b/src/app/locations/sundar-nagar/layout.tsx
@@ -16,6 +16,9 @@ export const metadata: Metadata = {
     'Premium NEET coaching Delhi',
     'NEET coaching near India Gate',
   ],
+  alternates: {
+    canonical: 'https://cerebrumbiologyacademy.com/locations/sundar-nagar',
+  },
   openGraph: {
     title: 'NEET Biology Coaching Sundar Nagar | Cerebrum Academy',
     description:

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -23,6 +23,8 @@ export default function robots(): MetadataRoute.Robots {
           '/boards/',
           '/portal/',
           '/counselor/',
+          // Block CSS deployment files with ?dpl= hashes (150+ crawl waste URLs)
+          '/_next/static/css/',
           // Block query parameter crawl waste (search, filters, etc.)
           '/blog?',
           '/courses?',
@@ -47,12 +49,12 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: 'Googlebot',
         allow: '/',
-        disallow: ['/dashboard/', '/api/', '/auth/', '/admin/', '/student/', '/analytics/'],
+        disallow: ['/dashboard/', '/api/', '/auth/', '/admin/', '/student/', '/analytics/', '/_next/static/css/', '/blog?', '/courses?'],
       },
       {
         userAgent: 'Bingbot',
         allow: '/',
-        disallow: ['/dashboard/', '/api/', '/auth/', '/admin/', '/student/', '/analytics/'],
+        disallow: ['/dashboard/', '/api/', '/auth/', '/admin/', '/student/', '/analytics/', '/_next/static/css/', '/blog?', '/courses?'],
       },
       // AI Search Engine Crawlers - Allow for GEO (Generative Engine Optimization)
       {


### PR DESCRIPTION
Add self-referencing canonical to 10 location layouts + dropper. Block CSS deployment URLs and query params in robots.ts for Googlebot/Bingbot. Fixes 3 GSC reports: alternate canonical (43p), crawled not indexed (150+ CSS), duplicate no canonical (29p).