### PR TITLE
fix: critical marketing fixes - dead CTA, wrong email, broken brochure

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -169,7 +169,7 @@ export default function ContactPage() {
     {
       icon: Mail,
       title: 'Email Us',
-      details: ['info@cerebrum.academy', 'admissions@cerebrum.academy'],
+      details: ['info@cerebrumbiologyacademy.com', 'admissions@cerebrumbiologyacademy.com'],
       color: 'bg-[#5a6d5a]',
     },
     {
@@ -183,8 +183,8 @@ export default function ContactPage() {
   const quickLinks = [
     { title: 'Book Free Demo Class', href: '/demo-booking', icon: BookOpen },
     {
-      title: 'Download Brochure',
-      href: '/brochure/cerebrum-biology-academy-brochure.pdf',
+      title: 'Request Brochure',
+      href: `https://wa.me/918826444334?text=${encodeURIComponent('Hi, I would like to receive the Cerebrum Biology Academy brochure. Please share it with me.')}`,
       icon: Target,
     },
     { title: 'Check Results', href: '/success-stories', icon: Award },

--- a/src/app/neet-coaching-fees/page.tsx
+++ b/src/app/neet-coaching-fees/page.tsx
@@ -585,7 +585,7 @@ export default function FeesPage() {
                 Call {CONTACT_INFO.phone.display.primary}
               </a>
               <a
-                href="#"
+                href="/book-free-demo"
                 className="inline-flex items-center justify-center gap-2 px-8 py-4 border-2 border-slate-300 text-slate-700 rounded-lg font-semibold text-lg hover:border-slate-400 hover:bg-slate-50 transition-colors"
               >
                 Book Free Demo

--- a/src/components/admissions/AdmissionsHeroStatic.tsx
+++ b/src/components/admissions/AdmissionsHeroStatic.tsx
@@ -1,5 +1,4 @@
 import { Award, Trophy, Download, Phone } from 'lucide-react'
-import Link from 'next/link'
 
 /**
  * Static Hero Component for Admissions Page
@@ -62,14 +61,15 @@ export function AdmissionsHeroStatic() {
               className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center lg:justify-start animate-fade-in-up"
               style={{ animationDelay: '0.4s' }}
             >
-              <Link
-                href="/brochure/cerebrum-admissions-brochure.pdf"
-                download="Cerebrum-Biology-Academy-Admissions-Brochure.pdf"
+              <a
+                href={`https://wa.me/918826444334?text=${encodeURIComponent('Hi, I am interested in admissions at Cerebrum Biology Academy. Please share the brochure and admission details.')}`}
+                target="_blank"
+                rel="noopener noreferrer"
                 className="inline-flex items-center justify-center border-2 border-white text-white hover:bg-white hover:text-blue-600 px-6 py-3 rounded-lg font-medium transition-colors w-full sm:w-auto"
               >
                 <Download className="w-5 h-5 mr-2" />
-                Download Brochure
-              </Link>
+                Request Brochure
+              </a>
               <a
                 href="#application-form"
                 className="inline-flex items-center justify-center bg-white text-blue-600 hover:bg-gray-100 px-6 py-3 rounded-lg font-medium transition-colors w-full sm:w-auto"


### PR DESCRIPTION
## Phase 1 Critical Fixes

- Fix dead Book Free Demo button on pricing page (href=# → /book-free-demo)
- Fix wrong email domain on contact page (cerebrum.academy → cerebrumbiologyacademy.com)
- Fix broken brochure PDF downloads (404) → WhatsApp request links
- Clean up unused Link import

**Impact:** Stops active lead bleeding on highest-intent pages