### PR TITLE
feat: Add email newsletter signup and enhance blog CTAs

### DIFF
--- a/src/components/blog/BlogNewsletterSignup.tsx
+++ b/src/components/blog/BlogNewsletterSignup.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import { useState } from 'react'
+import { Mail, CheckCircle, ArrowRight, BookOpen } from 'lucide-react'
+
+interface BlogNewsletterSignupProps {
+  articleSlug?: string
+  category?: string
+}
+
+/**
+ * Email-first newsletter signup component for blog pages.
+ * Captures email addresses for weekly NEET Biology tips newsletter.
+ * Complements the existing phone-based lead capture flow.
+ */
+export function BlogNewsletterSignup({ articleSlug, category }: BlogNewsletterSignupProps) {
+  const [email, setEmail] = useState('')
+  const [submitted, setSubmitted] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+
+  const validateEmail = (value: string): boolean => {
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+
+    if (!validateEmail(email)) {
+      setError('Please enter a valid email address')
+      return
+    }
+
+    setSubmitting(true)
+
+    try {
+      const response = await fetch('/api/blog/capture-lead', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          phone: '',
+          source: 'blog_newsletter',
+          articleSlug: articleSlug || 'unknown',
+          articleTitle: `Newsletter signup from ${category || 'blog'}`,
+        }),
+      })
+
+      if (response.ok) {
+        setSubmitted(true)
+      } else {
+        setError('Something went wrong. Please try again.')
+      }
+    } catch {
+      setError('Network error. Please try again.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (submitted) {
+    return (
+      <div className="my-10 p-6 bg-green-50 border border-green-200 rounded-2xl text-center">
+        <div className="flex items-center justify-center gap-2 text-green-700 mb-2">
+          <CheckCircle className="w-6 h-6" />
+          <span className="font-bold text-lg">You&apos;re subscribed!</span>
+        </div>
+        <p className="text-green-600 text-sm">
+          Check your inbox for weekly NEET Biology tips from Dr. Shekhar.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="my-10 p-6 sm:p-8 bg-gradient-to-br from-indigo-50 to-blue-50 border border-indigo-100 rounded-2xl">
+      <div className="flex items-start gap-4">
+        <div className="hidden sm:flex p-3 bg-indigo-100 rounded-xl">
+          <BookOpen className="w-6 h-6 text-indigo-600" />
+        </div>
+        <div className="flex-1">
+          <h3 className="text-lg font-bold text-gray-900 mb-1">
+            Get Weekly NEET Biology Tips
+          </h3>
+          <p className="text-sm text-gray-600 mb-4">
+            Join 5,000+ students receiving free chapter summaries, mnemonics, and exam strategies
+            every week from AIIMS faculty.
+          </p>
+
+          <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row gap-3">
+            <div className="relative flex-1">
+              <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="Enter your email address"
+                required
+                className="w-full pl-10 pr-4 py-3 text-sm bg-white text-gray-900 rounded-xl border border-gray-200 focus:border-indigo-400 focus:ring-2 focus:ring-indigo-100 focus:outline-none placeholder:text-gray-400"
+                style={{ fontSize: '16px' }}
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={submitting || !email}
+              className="px-5 py-3 font-semibold text-sm text-white bg-indigo-600 hover:bg-indigo-700 rounded-xl transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 whitespace-nowrap"
+            >
+              {submitting ? (
+                'Subscribing...'
+              ) : (
+                <>
+                  Subscribe Free
+                  <ArrowRight className="w-4 h-4" />
+                </>
+              )}
+            </button>
+          </form>
+
+          {error && (
+            <p className="mt-2 text-red-500 text-sm">{error}</p>
+          )}
+
+          <p className="mt-3 text-xs text-gray-400">
+            No spam. Unsubscribe anytime. We respect your privacy.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/blog/BlogPostPage.tsx
+++ b/src/components/blog/BlogPostPage.tsx
@@ -31,6 +31,7 @@ import { parseReadTime } from './utils'
 import { ArticleSchema, BreadcrumbSchema } from '@/components/seo/ArticleSchema'
 import { BlogExitIntentWrapper } from './BlogExitIntentWrapper'
 import { BlogWhatsAppQuery } from './BlogWhatsAppQuery'
+import { BlogNewsletterSignup } from './BlogNewsletterSignup'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeRaw from 'rehype-raw'
@@ -511,6 +512,12 @@ export function BlogPostPage({ meta, content, toc, relatedPosts, category }: Blo
                 category={meta.category}
                 neetChapter={meta.neetChapter}
                 tags={meta.tags}
+              />
+
+              {/* Newsletter Signup - Email-first capture */}
+              <BlogNewsletterSignup
+                articleSlug={meta.slug}
+                category={meta.category}
               />
 
               {/* Tags */}

--- a/src/components/blog/RelatedResources.tsx
+++ b/src/components/blog/RelatedResources.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { BookOpen, GraduationCap, Calendar, FileText, Award } from 'lucide-react'
+import { BookOpen, GraduationCap, Calendar, FileText, Award, Beaker } from 'lucide-react'
 
 interface RelatedResourcesProps {
   category?: string
@@ -9,14 +9,39 @@ interface RelatedResourcesProps {
   tags?: string[]
 }
 
+// Map NEET chapters to specific course pages for targeted CTAs
+const chapterToCourse: Record<string, { slug: string; label: string }> = {
+  'Human Physiology': { slug: '/courses/class-12', label: 'Class 12 NEET Biology' },
+  'Genetics': { slug: '/courses/class-12', label: 'Class 12 Genetics Module' },
+  'Molecular Biology': { slug: '/courses/class-12', label: 'Class 12 Molecular Biology' },
+  'Reproduction': { slug: '/courses/class-12', label: 'Class 12 Reproduction Module' },
+  'Ecology': { slug: '/courses/class-12', label: 'Class 12 Ecology Module' },
+  'Evolution': { slug: '/courses/class-12', label: 'Class 12 Evolution Module' },
+  'Plant Physiology': { slug: '/courses/class-11', label: 'Class 11 Plant Biology' },
+  'Cell Biology': { slug: '/courses/class-11', label: 'Class 11 Cell Biology' },
+  'Plant Kingdom': { slug: '/courses/class-11', label: 'Class 11 Plant Kingdom' },
+  'Animal Kingdom': { slug: '/courses/class-11', label: 'Class 11 Animal Kingdom' },
+  'Biomolecules': { slug: '/courses/class-11', label: 'Class 11 Biomolecules' },
+  'Structural Organisation': { slug: '/courses/class-11', label: 'Class 11 Structural Organisation' },
+}
+
+// Map blog categories to specific course pages
+const categoryToCourse: Record<string, { slug: string; label: string }> = {
+  'chapter-guides': { slug: '/courses', label: 'Chapter-wise Courses' },
+  'ncert-analysis': { slug: '/courses', label: 'NCERT-based Courses' },
+  'mnemonics': { slug: '/free-resources', label: 'Free Study Materials' },
+  'olympiad': { slug: '/olympiad-coaching', label: 'Olympiad Coaching Program' },
+}
+
 // Hub pages that should receive internal links
 const hubPages = [
   {
-    slug: '/demo-booking',
+    slug: '/book-free-demo',
     title: 'Book FREE Demo Class',
     description: 'Experience our teaching methodology with AIIMS faculty',
     icon: Calendar,
     color: 'bg-blue-50 text-blue-600 border-blue-200',
+    iconBg: 'bg-blue-100',
     matchCategories: ['neet-preparation', 'study-tips', 'chapter-guides'],
     matchChapters: ['all'],
     priority: 1,
@@ -27,6 +52,7 @@ const hubPages = [
     description: 'NEET Foundation, Dropper, and Crash Courses',
     icon: GraduationCap,
     color: 'bg-purple-50 text-purple-600 border-purple-200',
+    iconBg: 'bg-purple-100',
     matchCategories: ['neet-preparation', 'biology-concepts'],
     matchChapters: ['all'],
     priority: 2,
@@ -37,6 +63,7 @@ const hubPages = [
     description: 'AIIMS-trained teachers with 2500+ NEET selections',
     icon: Award,
     color: 'bg-green-50 text-green-600 border-green-200',
+    iconBg: 'bg-green-100',
     matchCategories: ['neet-preparation', 'success-stories'],
     matchChapters: ['all'],
     priority: 3,
@@ -47,6 +74,7 @@ const hubPages = [
     description: 'Chapter-wise and full-length mock tests',
     icon: FileText,
     color: 'bg-orange-50 text-orange-600 border-orange-200',
+    iconBg: 'bg-orange-100',
     matchCategories: ['chapter-guides', 'biology-concepts'],
     matchChapters: ['Human Physiology', 'Genetics', 'Ecology', 'Plant Physiology', 'Cell Biology'],
     priority: 4,
@@ -57,6 +85,7 @@ const hubPages = [
     description: 'NCERT summaries, PYQs, and study materials',
     icon: BookOpen,
     color: 'bg-green-50 text-green-600 border-green-200',
+    iconBg: 'bg-green-100',
     matchCategories: ['chapter-guides', 'study-tips'],
     matchChapters: ['all'],
     priority: 5,
@@ -64,11 +93,38 @@ const hubPages = [
 ]
 
 export function RelatedResources({ category, neetChapter, tags }: RelatedResourcesProps) {
+  // Build dynamic course-specific resource if applicable
+  const courseMatch = neetChapter
+    ? chapterToCourse[neetChapter]
+    : category
+      ? categoryToCourse[category]
+      : null
+
+  // Build the final resource list
+  const dynamicPages = courseMatch
+    ? [
+        {
+          slug: courseMatch.slug,
+          title: courseMatch.label,
+          description: `Structured course covering ${neetChapter || category || 'this topic'} with AIIMS faculty`,
+          icon: Beaker,
+          color: 'bg-indigo-50 text-indigo-600 border-indigo-200',
+          iconBg: 'bg-indigo-100',
+          matchCategories: [] as string[],
+          matchChapters: [] as string[],
+          priority: 1.5,
+        },
+      ]
+    : []
+
   // Filter and sort hub pages based on content relevance
-  const relevantPages = hubPages
+  const relevantPages = [...dynamicPages, ...hubPages]
     .filter((page) => {
       // Always show demo-booking (highest conversion)
-      if (page.slug === '/demo-booking') return true
+      if (page.slug === '/book-free-demo') return true
+
+      // Show dynamic course page if matched
+      if (dynamicPages.some((d) => d.slug === page.slug && d.title === page.title)) return true
 
       // Match by category
       if (category && page.matchCategories.includes(category)) return true
@@ -76,7 +132,9 @@ export function RelatedResources({ category, neetChapter, tags }: RelatedResourc
       // Match by chapter
       if (neetChapter) {
         if (page.matchChapters.includes('all')) return true
-        if (page.matchChapters.some((ch) => neetChapter.toLowerCase().includes(ch.toLowerCase())))
+        if (
+          page.matchChapters.some((ch) => neetChapter.toLowerCase().includes(ch.toLowerCase()))
+        )
           return true
       }
 
@@ -93,6 +151,20 @@ export function RelatedResources({ category, neetChapter, tags }: RelatedResourc
 
       return false
     })
+    // Deduplicate by slug (keep the one with lower priority = higher importance)
+    .reduce(
+      (acc, page) => {
+        const existing = acc.find((p) => p.slug === page.slug)
+        if (!existing) {
+          acc.push(page)
+        } else if (page.priority < existing.priority) {
+          const idx = acc.indexOf(existing)
+          acc[idx] = page
+        }
+        return acc
+      },
+      [] as typeof hubPages
+    )
     .sort((a, b) => a.priority - b.priority)
     .slice(0, 3) // Show max 3 resources
 
@@ -109,14 +181,12 @@ export function RelatedResources({ category, neetChapter, tags }: RelatedResourc
           const Icon = page.icon
           return (
             <Link
-              key={page.slug}
+              key={`${page.slug}-${page.title}`}
               href={page.slug}
               className={`group p-4 rounded-xl border ${page.color} hover:shadow-md transition-all duration-300 hover:-translate-y-1`}
             >
               <div className="flex items-start gap-3">
-                <div
-                  className={`p-2 rounded-lg ${page.color.includes('blue') ? 'bg-blue-100' : page.color.includes('purple') ? 'bg-purple-100' : page.color.includes('green') ? 'bg-green-100' : page.color.includes('orange') ? 'bg-orange-100' : 'bg-green-100'}`}
-                >
+                <div className={`p-2 rounded-lg ${page.iconBg}`}>
                   <Icon className="w-5 h-5" />
                 </div>
                 <div className="flex-1 min-w-0">


### PR DESCRIPTION
## Summary
- New **BlogNewsletterSignup** component for email-first capture
- Enhanced **RelatedResources** with chapter-to-course mapping (12 chapters mapped)
- Updated blog lead capture API to support email-only newsletter signups
- Added `blog_newsletter` source type with tailored messaging

## Phase 5 of Marketing Fix Plan
Previously: Blog only captured phone numbers inline. No email newsletter opt-in.
Now: Email-first newsletter + topic-aware course links in related resources.