### PR TITLE
feat: Add /enroll redirect to canonical enrollment page

### DIFF
--- a/src/app/enroll/page.tsx
+++ b/src/app/enroll/page.tsx
@@ -1,0 +1,9 @@
+import { redirect } from 'next/navigation'
+
+/**
+ * /enroll shortcut - Redirects to the canonical /enrollment page.
+ * Keeps URLs consistent and consolidates enrollment at one location.
+ */
+export default function EnrollShortcut() {
+  redirect('/enrollment')
+}


### PR DESCRIPTION
## Summary
- Adds /enroll as a redirect to /enrollment
- The /enrollment page already has full Razorpay integration
- This ensures any "Enroll Now" CTAs can use either URL

Phase 7 of Marketing Fix Plan