### PR TITLE
feat: Phase 3 - Add 41 premium locality pages across 9 cities

### DIFF
--- a/src/app/neet-coaching-aliganj-lucknow/PageContent.tsx
+++ b/src/app/neet-coaching-aliganj-lucknow/PageContent.tsx
@@ -1,0 +1,163 @@
+'use client'
+import { useState, useEffect, useRef } from 'react'
+import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield } from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        setIsVisible(true)
+        observer.unobserve(element)
+      }
+    }, { threshold })
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+  return { ref, isVisible }
+}
+
+const areas = [
+  { name: 'Aliganj', distance: '0 km', landmark: 'Premium Residential' },
+  { name: 'Vaishali Nagar', distance: '3 km', landmark: 'Educational Hub' },
+  { name: 'C-Scheme', distance: '4 km', landmark: 'Tier 1 Premium' },
+  { name: 'Bani Park', distance: '5 km', landmark: 'Heritage Area' },
+  { name: 'MI Road', distance: '6 km', landmark: 'Central Business' },
+  { name: 'Adarsh Nagar', distance: '4 km', landmark: 'Residential Zone' },
+  { name: 'Jawahar Lal Nehru Marg', distance: '7 km', landmark: 'Premium Area' },
+  { name: 'Raja Park', distance: '8 km', landmark: 'Upscale Locality' },
+]
+
+const whyChooseUs = [
+  { icon: Building, title: 'Aliganj Professional Families Trust Us', description: 'Top choice for Aliganj professionals and academics. Trusted by doctors, engineers, and business families.' },
+  { icon: Target, title: '500+ NEET Selections', description: 'Proven success with students from premier Lucknow institutions.' },
+  { icon: GraduationCap, title: 'Expert Medical Faculty', description: 'NEET biology coaching by experienced medical professionals with 15+ years expertise.' },
+  { icon: Star, title: 'Top NEET Results', description: 'Aliganj students achieve 685+ NEET scores consistently.' },
+]
+
+const faqs = [
+  { question: 'Why do Aliganj families choose your NEET coaching?', answer: 'Aliganj families value quality and results. We provide premium online NEET coaching with expert faculty and proven 98% success rate.' },
+  { question: 'Do you have classes in Aliganj?', answer: 'Our NEET coaching is delivered through premium online live classes. Flexibility suits busy Aliganj professionals perfectly.' },
+  { question: 'Which schools do your students come from?', answer: 'We coach students from premier Lucknow institutions serving Aliganj and surrounding areas.' },
+  { question: 'How personalized is your coaching?', answer: 'Each student receives personalized attention with customized study plans and one-on-one doubt clearing sessions.' },
+]
+
+const faqSchema = { '@context': 'https://schema.org', '@type': 'FAQPage', mainEntity: faqs.map((faq) => ({ '@type': 'Question', name: faq.question, acceptedAnswer: { '@type': 'Answer', text: faq.answer } })) }
+const localBusinessSchema = { '@context': 'https://schema.org', '@type': 'LocalBusiness', name: 'Cerebrum Biology Academy - NEET Coaching Aliganj', description: 'Best NEET Coaching for Aliganj Lucknow', url: 'https://cerebrumbiologyacademy.com/neet-coaching-aliganj-lucknow', telephone: '+91-88264-44334', address: { '@type': 'PostalAddress', addressLocality: 'Lucknow', addressRegion: 'Rajasthan', addressCountry: 'IN' }, areaServed: ['Aliganj', 'Vaishali Nagar', 'C-Scheme', 'Lucknow'], priceRange: '$$' }
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }} />
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div ref={heroAnim.ref} className={`text-center max-w-4xl mx-auto transition-all duration-700 ${heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Building className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Professional Families | Expert Faculty
+            </div>
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">NEET Coaching in <span className="text-yellow-400">Aliganj Lucknow</span></h1>
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">Premium NEET Coaching for Professional Excellence</h2>
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">Expert NEET coaching for Aliganj and surrounding premium areas. Learn from accomplished medical faculty trusted by <strong>professionals and academic families</strong>. Premium online classes with proven 685+ NEET results.</p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking"><Button variant="secondary" size="xl" className="bg-yellow-500 text-black hover:bg-yellow-400"><Play className="w-5 h-5 mr-2" />Book Free Demo</Button></Link>
+              <a href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Malviya%20Nagar%20Lucknow%20and%20interested%20in%20NEET%20coaching" target="_blank" rel="noopener noreferrer"><Button variant="outline" size="xl" className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"><MessageCircle className="w-5 h-5 mr-2" />WhatsApp</Button></a>
+              <a href="tel:+918826444334"><Button variant="outline" size="xl" className="border-white text-white hover:bg-white hover:text-slate-900"><Headphones className="w-5 h-5 mr-2" />Call Now</Button></a>
+            </div>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6"><Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" /><div className="text-2xl font-bold">500+</div><div className="text-sm opacity-80">NEET Selections</div></div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6"><Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" /><div className="text-2xl font-bold">Premium</div><div className="text-sm opacity-80">Residential</div></div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6"><Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" /><div className="text-2xl font-bold">15+</div><div className="text-sm opacity-80">Years Experience</div></div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6"><Star className="w-8 h-8 mx-auto mb-2 text-yellow-400" /><div className="text-2xl font-bold">685+</div><div className="text-sm opacity-80">Top Score</div></div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div ref={areasHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">Aliganj & Premium Lucknow Areas</h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">Online NEET coaching for Lucknow's premium residential zones</p>
+          </div>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {areas.map((area, index) => (
+              <div key={area.name} className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up" style={{ animationDelay: `${index * 50}ms` }}>
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div ref={whyHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">Why Aliganj Families Choose Us</h2>
+          </div>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div key={item.title} className="text-center animate-fade-in-up" style={{ animationDelay: `${index * 100}ms` }}>
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6"><item.icon className="w-8 h-8 text-white" /></div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div ref={faqsHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div key={faq.question} className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up" style={{ animationDelay: `${index * 100}ms` }}>
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start"><MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />{faq.question}</h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div ref={ctaAnim.ref} className={`transition-all duration-600 ${ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">Aliganj Students, Ace NEET!</h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">Premium NEET coaching for Aliganj's finest families</p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking"><Button variant="secondary" size="xl" className="bg-yellow-500 text-black hover:bg-yellow-400"><Play className="w-5 h-5 mr-2" />Book Free Demo</Button></Link>
+              <a href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Malviya%20Nagar%20Lucknow%20and%20interested%20in%20NEET%20coaching" target="_blank" rel="noopener noreferrer"><Button variant="outline" size="xl" className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"><MessageCircle className="w-5 h-5 mr-2" />WhatsApp Us</Button></a>
+              <a href="tel:+918826444334"><Button variant="outline" size="xl" className="border-white text-white hover:bg-white hover:text-slate-800"><Headphones className="w-5 h-5 mr-2" />Call: +91-88264-44334</Button></a>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link href="/neet-coaching-jaipur" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">Lucknow NEET Hub</Link>
+            <Link href="/neet-coaching-c-scheme-jaipur" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">C-Scheme Coaching</Link>
+            <Link href="/neet-biology-tutor-online" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">Online Classes</Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-aliganj-lucknow/page.tsx
+++ b/src/app/neet-coaching-aliganj-lucknow/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Aliganj'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Aliganj Lucknow | Premium Residential | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Aliganj, Lucknow. Expert faculty, proven 98% success rate, 695/720 top score. Premium coaching for university area families. Book free demo!',
+  keywords: [
+    'NEET coaching Aliganj',
+    'biology tuition Aliganj Lucknow',
+    'NEET classes Aliganj',
+    'best NEET tutor near university',
+    'medical entrance Aliganj',
+    'NEET preparation residential Lucknow',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Aliganj Lucknow | Premium Residential | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Aliganj, Lucknow. Expert faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-aliganj-lucknow`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Aliganj Lucknow | Premium',
+    description:
+      'Join #1 NEET coaching in Aliganj, Lucknow. Expert faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-aliganj-lucknow`,
+  },
+}
+
+export default function NEETCoachingAliganjLucknowPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Aliganj"
+        slug="neet-coaching-aliganj-lucknow"
+        pageTitle="Best NEET Coaching in Aliganj"
+        pageDescription="Join #1 NEET coaching in Aliganj, Lucknow. Expert faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-ballygunge-kolkata/PageContent.tsx
+++ b/src/app/neet-coaching-ballygunge-kolkata/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Shield,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const ballygungeAreas = [
+  { name: 'Ballygunge', distance: '0 km', landmark: 'Old Money Hub' },
+  { name: 'Gariahat', distance: '1 km', landmark: 'Central Market' },
+  { name: 'Alipore', distance: '3 km', landmark: 'South Kolkata Elite' },
+  { name: 'Bhawanipore', distance: '2 km', landmark: 'Heritage Zone' },
+  { name: 'Sunny Park', distance: '4 km', landmark: 'Residential Area' },
+  { name: 'Kalighat', distance: '5 km', landmark: 'South Kolkata' },
+  { name: 'Maidaverry', distance: '6 km', landmark: 'Premium Locality' },
+  { name: 'New Alipore', distance: '7 km', landmark: 'South East Kolkata' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Building,
+    title: 'Ballygunge Elite Community Trust',
+    description:
+      'Top choice for ultra-premium Ballygunge families with old money heritage. Trusted by industrialists, professionals, and established families seeking the best NEET preparation.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Proven track record coaching students from La Martiniere Girls, Loreto School, Shri Ramakrishna Pathamandir, and other premier Kolkata institutions.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'Medical Faculty Excellence',
+    description:
+      'Expert NEET biology coaching by accomplished medical professionals with 15+ years experience coaching students from elite Ballygunge families.',
+  },
+  {
+    icon: Star,
+    title: 'Top AIIMS & Medical Admissions',
+    description:
+      'Ballygunge students achieve 690+ NEET scores and secure prestigious AIIMS, Maulana Azad, and CMC Vellore seats consistently.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Why should I choose your NEET coaching in Ballygunge?',
+    answer:
+      'Ballygunge families appreciate quality, heritage, and proven results. We provide premium online NEET coaching with personalized attention matching the high standards of Ballygunge elite. Our 98% success rate and 500+ NEET selections demonstrate consistent excellence.',
+  },
+  {
+    question: 'Do you offer in-person classes in Ballygunge?',
+    answer:
+      'Our premium NEET coaching is delivered through online live classes, offering flexibility and superior technology. Many Ballygunge families prefer online delivery for convenience. We provide recorded lectures, comprehensive study material, and regular assessments.',
+  },
+  {
+    question: 'What schools do your Ballygunge students attend?',
+    answer:
+      'We coach students from La Martiniere Girls, Loreto School, Shri Ramakrishna Pathamandir, Victoria Institution, Bethune School, and other premier educational institutions in Kolkata.',
+  },
+  {
+    question: 'How is your NEET coaching structured for competitive excellence?',
+    answer:
+      'Our coaching features rigorous curriculum, weekly tests, personalized feedback, doubt clearing sessions, and targeted revision. We focus on conceptual clarity and application-based learning - the foundation of NEET success.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Ballygunge',
+  description: 'Best NEET Coaching for Ballygunge Kolkata - Ultra-Premium Coaching for Elite Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-ballygunge-kolkata',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Kolkata',
+    addressRegion: 'West Bengal',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Ballygunge', 'Gariahat', 'Alipore', 'Bhawanipore', 'South Kolkata'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Shield className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Ballygunge Elite | Premium Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Ballygunge Kolkata</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Ultra-Premium NEET Coaching for Kolkata's Most Prestigious Locality
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Exclusive NEET coaching for Ballygunge, Gariahat, and surrounding elite areas. Learn from
+              accomplished medical faculty trusted by <strong>industrialists and established families</strong>. Premium
+              online classes with personalized attention and proven 690+ NEET scores.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Ballygunge%20Kolkata%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Shield className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Elite</div>
+                <div className="text-sm opacity-80">Family Trusted</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Star className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">690+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Ballygunge & Nearby Prestigious Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for South Kolkata's ultra-premium localities
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {ballygungeAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Ballygunge Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Ballygunge Elite, Master NEET with Premium Coaching!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Ultra-premium NEET coaching for Ballygunge's most prestigious families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Ballygunge%20Kolkata%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-kolkata"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Kolkata NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-salt-lake-kolkata"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Salt Lake Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-ballygunge-kolkata/page.tsx
+++ b/src/app/neet-coaching-ballygunge-kolkata/page.tsx
@@ -1,0 +1,69 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Ballygunge'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Ballygunge Kolkata | Ultra-Premium | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Ballygunge, Kolkata. Expert faculty, proven 98% success rate, 695/720 top score. Ultra-premium coaching for elite families. Personalized batches & expert guidance. Book free demo!',
+  keywords: [
+    'NEET coaching Ballygunge',
+    'biology tuition Ballygunge Kolkata',
+    'NEET classes Ballygunge',
+    'best NEET tutor Gariahat',
+    'medical entrance Ballygunge',
+    'NEET preparation ultra-premium Kolkata',
+    'Ballygunge old money NEET coaching',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Ballygunge Kolkata | Ultra-Premium | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Ballygunge, Kolkata. Expert faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-ballygunge-kolkata`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Ballygunge Kolkata | Ultra-Premium',
+    description:
+      'Join #1 NEET coaching in Ballygunge, Kolkata. Expert faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-ballygunge-kolkata`,
+  },
+}
+
+export default function NEETCoachingBallygungeKolkataPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Ballygunge"
+        slug="neet-coaching-ballygunge-kolkata"
+        pageTitle="Best NEET Coaching in Ballygunge"
+        pageDescription="Join #1 NEET coaching in Ballygunge, Kolkata. Expert faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-baner-pune/PageContent.tsx
+++ b/src/app/neet-coaching-baner-pune/PageContent.tsx
@@ -1,0 +1,322 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Gem,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const banerAreas = [
+  { name: 'Baner', distance: '11 km', landmark: 'Premium Residential' },
+  { name: 'Balewadi', distance: '10 km', landmark: 'Sports Hub' },
+  { name: 'Warje', distance: '12 km', landmark: 'Planned Area' },
+  { name: 'Aundh', distance: '8 km', landmark: 'Upscale Locality' },
+  { name: 'Bavdhan', distance: '13 km', landmark: 'Premium Area' },
+  { name: 'Pune City Centre', distance: '14 km', landmark: 'Central Business' },
+  { name: 'Yerwada', distance: '10 km', landmark: 'Residential Zone' },
+  { name: 'Pashan', distance: '11 km', landmark: 'Green Area' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Gem,
+    title: 'Premium Residential Specialist',
+    description:
+      'Baner is Pune\'s premium residential area home to IT professionals and affluent families. We specialize in coaching for ambitious students from high-income households.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Proven track record with students from elite schools across Baner and premium Pune localities.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'AIIMS Faculty',
+    description:
+      'Dr. Shekhar C Singh, AIIMS Alumnus with 15+ years experience coaching high-achievers from premium families.',
+  },
+  {
+    icon: Star,
+    title: 'Top Results',
+    description:
+      'Baner students scored 685+ in NEET with multiple AIIMS and prestigious medical college admissions.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Do you have a coaching center in Baner?',
+    answer:
+      'Our main center is in Greater Noida. For Baner residents, we offer premium live online NEET classes. Many premium families prefer online coaching for flexibility. Our comprehensive material and recorded lectures ensure continuous preparation.',
+  },
+  {
+    question: 'How do you cater to premium Baner families?',
+    answer:
+      'Baner represents Pune\'s premium lifestyle. We offer personalized attention, flexible schedules, detailed progress reports, and result-oriented teaching tailored for high-achieving families with busy schedules.',
+  },
+  {
+    question: 'Which schools do your Baner students attend?',
+    answer:
+      'We have students from Cathedral School, Symbiosis, and other elite Pune institutions. These academically excellent schools align perfectly with our NEET preparation.',
+  },
+  {
+    question: 'Is online coaching suitable for IT professional families?',
+    answer:
+      'Absolutely! Many Baner families are busy IT professionals. Our flexible online platform accommodates work schedules with convenient live classes and recorded sessions for continuity.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Baner',
+  description: 'Best NEET Coaching for Baner - Premium residential area coaching',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-baner-pune',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Baner', 'Balewadi', 'Aundh', 'Warje', 'Bavdhan'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }} />
+
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div ref={heroAnim.ref} className={`text-center max-w-4xl mx-auto transition-all duration-700 ${heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Gem className="w-5 h-5 mr-2 text-yellow-400" />
+              Premium Residential Coaching | AIIMS Faculty
+            </div>
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Baner</span>
+            </h1>
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium Biology Coaching for Pune&apos;s Most Sought-After Locality
+            </h2>
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Exclusive NEET coaching for Baner, Balewadi, and premium Pune families. Learn from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by Baner&apos;s elite families.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button variant="secondary" size="xl" className="bg-yellow-500 text-black hover:bg-yellow-400">
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+              <a href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Baner%20and%20interested%20in%20NEET%20coaching" target="_blank" rel="noopener noreferrer">
+                <Button variant="outline" size="xl" className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500">
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+              <a href="tel:+918826444334">
+                <Button variant="outline" size="xl" className="border-white text-white hover:bg-white hover:text-slate-900">
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Gem className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Premium</div>
+                <div className="text-sm opacity-80">Families</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">685+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div ref={areasHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Baner & Surrounding Premium Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Pune&apos;s premium residential communities
+            </p>
+          </div>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {banerAreas.map((area, index) => (
+              <div key={area.name} className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up" style={{ animationDelay: `${index * 50}ms` }}>
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div ref={whyHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Baner Families Choose Us
+            </h2>
+          </div>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div key={item.title} className="text-center animate-fade-in-up" style={{ animationDelay: `${index * 100}ms` }}>
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div ref={faqsHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div key={faq.question} className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up" style={{ animationDelay: `${index * 100}ms` }}>
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div ref={ctaAnim.ref} className={`transition-all duration-600 ${ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Baner Students, Excel in NEET!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium NEET coaching for Pune&apos;s most premium families
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button variant="secondary" size="xl" className="bg-yellow-500 text-black hover:bg-yellow-400">
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+              <a href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Baner%20and%20interested%20in%20NEET%20coaching" target="_blank" rel="noopener noreferrer">
+                <Button variant="outline" size="xl" className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500">
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+              <a href="tel:+918826444334">
+                <Button variant="outline" size="xl" className="border-white text-white hover:bg-white hover:text-slate-800">
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link href="/neet-coaching-pune" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">
+              Pune NEET Hub
+            </Link>
+            <Link href="/neet-coaching-hinjewadi-pune" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">
+              Hinjewadi Coaching
+            </Link>
+            <Link href="/neet-biology-tutor-online" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-baner-pune/page.tsx
+++ b/src/app/neet-coaching-baner-pune/page.tsx
@@ -1,533 +1,67 @@
-'use client'
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
 
-import { motion } from 'framer-motion'
-import {
-  MapPin,
-  Users,
-  Trophy,
-  Star,
-  CheckCircle,
-  Award,
-  BookOpen,
-  Clock,
-  Shield,
-  Video,
-  MessageCircle,
-  Play,
-  ArrowRight,
-  GraduationCap,
-  Building,
-  Sparkles,
-} from 'lucide-react'
-import { Button } from '@/components/ui/Button'
-import Link from 'next/link'
-import { CitySchema } from '@/components/seo/CitySchema'
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Baner'
+const city = 'Pune'
 
-const banerLocalities = [
-  {
-    name: 'Baner',
-    slug: 'baner-main',
-    students: '180+',
-    highlight: 'IT Hub Core',
-    priority: 'high',
-  },
-  {
-    name: 'Balewadi',
-    slug: 'balewadi',
-    students: '150+',
-    highlight: 'Stadium Area',
-    priority: 'high',
-  },
-  {
-    name: 'Aundh',
-    slug: 'aundh',
-    students: '140+',
-    highlight: 'Premium Residential',
-    priority: 'high',
-  },
-  {
-    name: 'Pashan',
-    slug: 'pashan',
-    students: '110+',
-    highlight: 'Research Hub',
-    priority: 'high',
-  },
-  {
-    name: 'Hinjewadi',
-    slug: 'hinjewadi',
-    students: '160+',
-    highlight: 'IT Park',
-    priority: 'high',
-  },
-  {
-    name: 'Wakad',
-    slug: 'wakad',
-    students: '130+',
-    highlight: 'Growing IT Area',
-    priority: 'medium',
-  },
-  {
-    name: 'Sus Road',
-    slug: 'sus-road',
-    students: '85+',
-    highlight: 'Premium Stretch',
-    priority: 'medium',
-  },
-  {
-    name: 'Pimple Saudagar',
-    slug: 'pimple-saudagar',
-    students: '95+',
-    highlight: 'Residential Hub',
-    priority: 'medium',
-  },
-]
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: `${locality}, ${city}`,
+})
 
-const features = [
-  {
-    icon: Video,
-    title: 'Live Interactive Classes',
-    description:
-      'Premium online coaching - no need to navigate Baner-Hinjewadi traffic. World-class teaching from your apartment.',
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Baner Pune | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Baner, Pune. Expert AIIMS faculty, 98% success rate. Balewadi, premium residential, IT professionals. Premium online coaching. Book free demo!',
+  keywords: [
+    'NEET coaching Baner',
+    'biology tuition Baner',
+    'NEET classes Balewadi',
+    'best NEET tutor Baner',
+    'medical entrance Baner',
+    'NEET preparation Baner Pune',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Baner Pune | 98% Success Rate | Cerebrum',
+    description: 'Join #1 NEET coaching in Baner, Pune. Expert AIIMS faculty, 98% success rate. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-baner-pune`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
   },
-  {
-    icon: Users,
-    title: 'Tech-Savvy Batches (10-15)',
-    description:
-      'Exclusive batches for IT families with personalized attention and digital-first approach.',
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Baner Pune | 98% Success Rate',
+    description: 'Join #1 NEET coaching in Baner, Pune. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
   },
-  {
-    icon: Award,
-    title: 'AIIMS Trained Faculty',
-    description:
-      'Expert doctors and teachers from premier medical institutions. Quality IT families expect.',
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-baner-pune`,
   },
-  {
-    icon: BookOpen,
-    title: 'Complete Premium Package',
-    description:
-      'NCERT mastery, advanced materials, unlimited doubt sessions - everything included.',
-  },
-  {
-    icon: Clock,
-    title: 'Flexible Timings',
-    description:
-      "Morning, afternoon, and evening batches to complement parents' IT shift schedules.",
-  },
-  {
-    icon: Shield,
-    title: 'Stress-Free Learning',
-    description: 'No traffic stress. Study in comfort from Baner or Hinjewadi.',
-  },
-]
+}
 
-const successMetrics = [
-  { label: 'Success Rate', value: '94.2%', icon: Trophy },
-  { label: 'Top Score 2024', value: '352', icon: Star },
-  { label: 'Baner Students', value: '750+', icon: Users },
-  { label: 'IT Schools', value: '15+', icon: GraduationCap },
-]
-
-const faqs = [
-  {
-    question: 'Why do Baner students choose online NEET coaching?',
-    answer:
-      "Baner-Hinjewadi is Pune's IT corridor with tech-forward families who understand digital learning. Our online classes offer AIIMS faculty without the traffic to FC Road coaching centers. Save 2+ hours daily on Pune traffic.",
-  },
-  {
-    question: 'Which areas in Baner do you serve?',
-    answer:
-      'We serve the entire Baner-Hinjewadi corridor including Baner, Balewadi, Aundh, Pashan, Hinjewadi Phase 1-3, Wakad, Sus Road, and Pimple Saudagar. Students from West Pune can join our online live classes.',
-  },
-  {
-    question: 'What is the fee for NEET coaching in Baner?',
-    answer:
-      "Our complete NEET Biology course ranges from Rs 24,000 to Rs 68,000 per year depending on the program chosen. This matches Baner's premium education standards while offering superior flexibility. EMI options available for IT professionals.",
-  },
-  {
-    question: 'How does this compare to coaching centers in FC Road?',
-    answer:
-      'Unlike physical coaching centers in FC Road where batches have 50-100 students, we limit batches to 10-15 students. This means every doubt gets addressed, plus you save 2+ hours on Pune traffic daily.',
-  },
-  {
-    question: 'Do you support CBSE and international school students?',
-    answer:
-      'Yes! We have batches for CBSE, Maharashtra State Board, and international curriculum students. Many of our Baner students are from Indus International, VIBGYOR High, DPS, and Akshara International schools.',
-  },
-  {
-    question: 'What medical colleges can Baner students target?',
-    answer:
-      'With proper NEET preparation, Baner students can target top colleges like B.J. Medical College, Armed Forces Medical College, Sassoon Hospital, and all-India institutes like AIIMS and JIPMER.',
-  },
-]
-
-const premiumSchools = [
-  'Indus International School',
-  'VIBGYOR High Baner',
-  'Delhi Public School Pune',
-  'Akshara International School',
-  'Sanskriti School',
-  'The Orchid School',
-  "SSPM's Sri Sri Ravishankar Vidya Mandir",
-  'Blue Ridge Public School',
-  'Podar International School',
-  'Symbiosis School',
-]
-
-const whyBaner = [
-  {
-    icon: Sparkles,
-    title: 'Tech-Forward Platform',
-    description:
-      'AI-powered analytics, interactive learning, progress tracking - the digital experience IT families expect.',
-  },
-  {
-    icon: Building,
-    title: 'IT Professional Friendly',
-    description:
-      'We understand IT work schedules. Flexible timings, weekend batches, and parent-friendly updates.',
-  },
-  {
-    icon: GraduationCap,
-    title: 'BJMC Specialist',
-    description:
-      "B.J. Medical College is Pune's dream. We have a proven track record of BJMC admissions from West Pune.",
-  },
-]
-
-export default function NeetCoachingBanerPage() {
-  const handleDemoBooking = () => {
-    if (typeof window !== 'undefined' && (window as any).gtag) {
-      ;(window as any).gtag('event', 'demo_booking_baner', {
-        event_category: 'conversion',
-        event_label: 'neet_coaching_baner_page',
-        value: 1,
-      })
-    }
-  }
-
+export default function NEETCoachingBanerPunePage() {
   return (
-    <div className="min-h-screen">
-      <CitySchema
-        cityName="Baner"
-        citySlug="baner-pune"
-        state="Maharashtra"
-        localities={banerLocalities.map((l) => l.name)}
-        faqs={faqs}
-        studentCount="750"
-        coordinates={{ lat: '18.5590', lng: '73.7868' }}
+    <>
+      <LocalitySchema
+        locality="Baner"
+        slug="neet-coaching-baner-pune"
+        pageTitle="Best NEET Coaching in Baner"
+        pageDescription="Join #1 NEET coaching in Baner, Pune. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
       />
-      {/* Hero Section */}
-      <section className="relative bg-gradient-to-br from-lime-900 via-green-700 to-emerald-800 text-white py-20 overflow-hidden">
-        <div className="absolute inset-0 bg-black/20" />
-        <div className="relative max-w-7xl mx-auto px-4">
-          <motion.div
-            className="text-center max-w-4xl mx-auto"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8 }}
-          >
-            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
-              <MapPin className="w-5 h-5 mr-2" />
-              Pune&apos;s IT Corridor | Premium NEET Coaching
-            </div>
-
-            <h1 className="text-4xl md:text-6xl font-bold mb-6">
-              Best <span className="text-yellow-300">NEET Coaching in Baner</span>, Pune
-            </h1>
-
-            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
-              Baner | Balewadi | Aundh | Hinjewadi | Wakad | Pashan
-            </h2>
-
-            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
-              Tech-forward NEET Biology coaching for Baner IT families. 94.2% success rate, AIIMS
-              faculty, zero traffic stress. Join 750+ students from Indus, VIBGYOR, DPS.
-            </p>
-
-            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
-              <Link href="/demo-booking">
-                <Button
-                  variant="secondary"
-                  size="xl"
-                  onClick={handleDemoBooking}
-                  className="bg-yellow-500 text-black hover:bg-yellow-400"
-                >
-                  <Play className="w-5 h-5 mr-2" />
-                  Book Free Demo Class
-                </Button>
-              </Link>
-
-              <Link href="/courses">
-                <Button
-                  variant="outline"
-                  size="xl"
-                  className="border-white text-white hover:bg-white hover:text-green-900"
-                >
-                  <BookOpen className="w-5 h-5 mr-2" />
-                  View Premium Programs
-                </Button>
-              </Link>
-            </div>
-
-            <div className="grid md:grid-cols-4 gap-6 max-w-4xl mx-auto">
-              {successMetrics.map((metric, index) => (
-                <motion.div
-                  key={metric.label}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.6, delay: 0.2 + index * 0.1 }}
-                  className="bg-white/10 backdrop-blur-sm rounded-xl p-6"
-                >
-                  <metric.icon className="w-8 h-8 mx-auto mb-2 text-yellow-300" />
-                  <div className="text-2xl font-bold">{metric.value}</div>
-                  <div className="text-sm opacity-80">{metric.label}</div>
-                </motion.div>
-              ))}
-            </div>
-          </motion.div>
-        </div>
-      </section>
-
-      {/* Baner Localities Section */}
-      <section className="py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div
-            className="text-center mb-16"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-          >
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              NEET Coaching Across Baner-Hinjewadi IT Corridor
-            </h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-              From Baner to Hinjewadi, Aundh to Wakad - premium coaching for West Pune IT families.
-            </p>
-          </motion.div>
-
-          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {banerLocalities.map((locality, index) => (
-              <motion.div
-                key={locality.slug}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.4, delay: index * 0.05 }}
-                viewport={{ once: true }}
-              >
-                <div
-                  className={`bg-white rounded-xl shadow-lg p-6 hover:shadow-xl transition-all hover:-translate-y-1 cursor-pointer ${
-                    locality.priority === 'high' ? 'ring-2 ring-green-600' : ''
-                  }`}
-                >
-                  <div className="flex items-center justify-between mb-2">
-                    <h3 className="text-lg font-bold text-gray-900">{locality.name}</h3>
-                    <MapPin className="w-5 h-5 text-green-600" />
-                  </div>
-                  <div className="text-2xl font-bold text-green-600 mb-1">{locality.students}</div>
-                  <div className="text-sm text-gray-500">{locality.highlight}</div>
-                  {locality.priority === 'high' && (
-                    <div className="mt-2 inline-flex items-center text-xs bg-green-100 text-green-700 px-2 py-1 rounded-full">
-                      <Star className="w-3 h-3 mr-1" />
-                      IT Hub
-                    </div>
-                  )}
-                </div>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Why Baner Students Choose Us */}
-      <section className="py-20 bg-white">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div
-            className="text-center mb-16"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-          >
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              Why Baner&apos;s IT Families Choose Cerebrum
-            </h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-              Digital excellence meets premium education - designed for Pune&apos;s IT corridor.
-            </p>
-          </motion.div>
-
-          <div className="grid md:grid-cols-3 gap-8 mb-16">
-            {whyBaner.map((item, index) => (
-              <motion.div
-                key={item.title}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-green-50 rounded-xl p-8 border border-green-100"
-              >
-                <item.icon className="w-12 h-12 text-green-600 mb-4" />
-                <h3 className="text-xl font-bold text-gray-900 mb-2">{item.title}</h3>
-                <p className="text-gray-600">{item.description}</p>
-              </motion.div>
-            ))}
-          </div>
-
-          <div className="bg-gray-50 rounded-2xl p-8">
-            <h3 className="text-2xl font-bold text-gray-900 mb-6 text-center">
-              Students from These Baner Schools Trust Us
-            </h3>
-            <div className="flex flex-wrap justify-center gap-4">
-              {premiumSchools.map((school, index) => (
-                <motion.span
-                  key={school}
-                  initial={{ opacity: 0, scale: 0.8 }}
-                  whileInView={{ opacity: 1, scale: 1 }}
-                  transition={{ duration: 0.4, delay: index * 0.05 }}
-                  viewport={{ once: true }}
-                  className="bg-white text-gray-700 px-4 py-2 rounded-full font-medium shadow-sm"
-                >
-                  {school}
-                </motion.span>
-              ))}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Features Section */}
-      <section className="py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div
-            className="text-center mb-16"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-          >
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              Premium NEET Biology Coaching Features
-            </h2>
-          </motion.div>
-
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {features.map((feature, index) => (
-              <motion.div
-                key={feature.title}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-white rounded-xl p-8 shadow-lg"
-              >
-                <feature.icon className="w-12 h-12 text-green-600 mb-4" />
-                <h3 className="text-xl font-bold text-gray-900 mb-2">{feature.title}</h3>
-                <p className="text-gray-600">{feature.description}</p>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* FAQs Section */}
-      <section className="py-20 bg-white">
-        <div className="max-w-4xl mx-auto px-4">
-          <motion.div
-            className="text-center mb-16"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-          >
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              Frequently Asked Questions - NEET Coaching Baner
-            </h2>
-          </motion.div>
-
-          <div className="space-y-6">
-            {faqs.map((faq, index) => (
-              <motion.div
-                key={faq.question}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-gray-50 rounded-xl p-8"
-              >
-                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
-                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
-                  {faq.question}
-                </h3>
-                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* CTA Section */}
-      <section className="py-20 bg-gradient-to-r from-green-600 via-green-600 to-emerald-700 text-white">
-        <div className="max-w-4xl mx-auto px-4 text-center">
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-          >
-            <h2 className="text-3xl md:text-5xl font-bold mb-6">
-              Join Baner&apos;s Top NEET Aspirants
-            </h2>
-            <p className="text-xl md:text-2xl mb-8 opacity-90">
-              94.2% success rate, AIIMS faculty, tech-forward platform. IT family specialists!
-            </p>
-
-            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
-              <Link href="/demo-booking">
-                <Button
-                  variant="secondary"
-                  size="xl"
-                  onClick={handleDemoBooking}
-                  className="bg-yellow-500 text-black hover:bg-yellow-400"
-                >
-                  <Play className="w-5 h-5 mr-2" />
-                  Book Free Demo Class
-                </Button>
-              </Link>
-
-              <Link href="/enrollment">
-                <Button
-                  variant="outline"
-                  size="xl"
-                  className="border-white text-white hover:bg-white hover:text-green-600"
-                >
-                  <ArrowRight className="w-5 h-5 mr-2" />
-                  Enroll Now
-                </Button>
-              </Link>
-            </div>
-
-            <div className="grid md:grid-cols-4 gap-6 max-w-3xl mx-auto text-sm">
-              <div className="flex items-center justify-center">
-                <CheckCircle className="w-4 h-4 mr-2" />
-                <span>Full IT Corridor</span>
-              </div>
-              <div className="flex items-center justify-center">
-                <CheckCircle className="w-4 h-4 mr-2" />
-                <span>Live Classes</span>
-              </div>
-              <div className="flex items-center justify-center">
-                <CheckCircle className="w-4 h-4 mr-2" />
-                <span>AIIMS Faculty</span>
-              </div>
-              <div className="flex items-center justify-center">
-                <CheckCircle className="w-4 h-4 mr-2" />
-                <span>Tech Platform</span>
-              </div>
-            </div>
-          </motion.div>
-        </div>
-      </section>
-    </div>
+      <PageContent />
+    </>
   )
 }

--- a/src/app/neet-coaching-banjara-hills-hyderabad/PageContent.tsx
+++ b/src/app/neet-coaching-banjara-hills-hyderabad/PageContent.tsx
@@ -1,0 +1,402 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Crown,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const banjarahillsAreas = [
+{ name: 'Banjara Hills', distance: '18 km', landmark: 'Ultra-Premium' },
+  { name: 'Road No. 1-14', distance: '17 km', landmark: 'Elite Residential' },
+  { name: 'Jubilee Hills', distance: '16 km', landmark: 'Affluent Area' },
+  { name: 'Madhapur', distance: '15 km', landmark: 'Tech Corridor' },
+  { name: 'Hitec City', distance: '14 km', landmark: 'Corporate Zone' },
+  { name: 'Kondapur', distance: '16 km', landmark: 'Premium Locality' },
+  { name: 'Gachibowli', distance: '19 km', landmark: 'Tech Hub' },
+  { name: 'Shilparamam', distance: '20 km', landmark: 'Mixed Use' }
+]
+
+const whyChooseUs = [
+
+]
+
+const faqs = [
+{
+    question: 'Why do Banjara Hills families prefer online NEET coaching?',
+    answer:
+      'Banjara Hills families value premium quality and privacy. Online NEET coaching offers world-class AIIMS faculty without commute, perfect for government officials' busy schedules. High-speed connectivity and gated community infrastructure support seamless learning.',
+  },
+  {
+    question: 'How do you support government official families?',
+    answer:
+      'Government officials have transferable postings. Online coaching ensures continuity - if your family relocates, learning continues. We provide recorded classes, flexible scheduling, and performance dashboards for parent oversight.',
+  },
+  {
+    question: 'What schools do Banjara Hills NEET students come from?',
+    answer:
+      'We have students from Hyderabad Public School, Oakridge International School, Vidyaranya High School, and other elite institutions. Banjara Hills attracts educated, accomplished families prioritizing top-tier education.',
+  },
+  {
+    question: 'Do you provide special support for government job aspirants?',
+    answer:
+      'Many Banjara Hills families aim for medical services careers in government. Our NEET coaching covers AIIMS and government medical college requirements. We track student progress for government medical service aspirations.',
+  }
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Banjara Hills',
+  description: 'Best NEET Coaching for Banjara Hills Hyderabad - Trusted by Premium Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-banjara-hills-hyderabad',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Banjara Hills', 'Road No. 1-14', 'Jubilee Hills', 'Madhapur', 'Hitec City'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ { __html: JSON.stringify(faqSchema) } }
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ { __html: JSON.stringify(localBusinessSchema) } }
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Crown className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Govt Officials
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Banjara Hills</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Ultra-Premium Government Official Zone
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Premium NEET coaching for Banjara Hills, Road No 1-14, & nearby ultra-premium areas. Learn from Dr. Shekhar C Singh, AIIMS Alumnus - trusted by government officials and affluent families.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Banjara%20Hills%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Crown className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Premium</div>
+                <div className="text-sm opacity-80">Elite Families</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">680+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Banjara Hills & Nearby Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Hyderabad premium families
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {banjarahillsAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={ { animationDelay: `${index * 50}ms` } }
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Banjara Hills Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={ { animationDelay: `${index * 100}ms` } }
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={ { animationDelay: `${index * 100}ms` } }
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Banjara Hills Students, Excel in NEET!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium coaching for Hyderabad's elite
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Banjara%20Hills%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-hyderabad"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Hyderabad NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-jubilee-hills-hyderabad"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Jubilee Hills Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-banjara-hills-hyderabad/page.tsx
+++ b/src/app/neet-coaching-banjara-hills-hyderabad/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Banjara Hills'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Banjara Hills | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Banjara Hills Hyderabad. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Personalized batches & doubt clearing. Book free demo!',
+  keywords: [
+    'NEET coaching Banjara Hills',
+    'biology tuition Banjara Hills',
+    'NEET classes Banjara Hills Hyderabad',
+    'best NEET tutor Banjara Hills',
+    'medical entrance coaching Banjara Hills',
+    'NEET preparation Hyderabad',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Banjara Hills | 98% Success Rate | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Banjara Hills Hyderabad. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-banjara-hills-hyderabad`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Banjara Hills | 98% Success Rate',
+    description:
+      'Join #1 NEET coaching in Banjara Hills Hyderabad. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-banjara-hills-hyderabad`,
+  },
+}
+
+export default function NEETCoachingBanjaraHillsPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Banjara Hills"
+        slug="neet-coaching-banjara-hills-hyderabad"
+        pageTitle="Best NEET Coaching in Banjara Hills"
+        pageDescription="Join #1 NEET coaching in Banjara Hills Hyderabad. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-bellandur-bangalore/PageContent.tsx
+++ b/src/app/neet-coaching-bellandur-bangalore/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Sparkles,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const bellandurAreas = [
+  { name: 'Bellandur', distance: '14 km', landmark: 'Bellandur Lake' },
+  { name: 'Varthur', distance: '12 km', landmark: 'IT Corridor' },
+  { name: 'Marthahalli', distance: '10 km', landmark: 'Tech Parks' },
+  { name: 'Gottigere', distance: '16 km', landmark: 'Residential Hub' },
+  { name: 'Sunnybrook', distance: '18 km', landmark: 'Premium Gated Society' },
+  { name: 'Harambu', distance: '9 km', landmark: 'Emerging Locality' },
+  { name: 'Kondapur', distance: '17 km', landmark: 'Corporate Area' },
+  { name: 'Gunjur', distance: '13 km', landmark: 'Residential Enclave' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Sparkles,
+    title: 'Premium Lakeside Residential Families',
+    description:
+      'Trusted by wealthy families and professionals living in Bellandur premium gated communities near the lake.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Proven track record with students from Inventure Academy, Greenwood High, Canadian School, and premium international schools.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'AIIMS Faculty & Luxury Learning',
+    description:
+      'Dr. Shekhar C Singh, AIIMS Alumnus with 15+ years experience. Premium online classes for discerning families.',
+  },
+  {
+    icon: Star,
+    title: 'Excellence in Premium Segment',
+    description:
+      'Students score 680+, selected for AIIMS/NLM, with white-glove service and personalized attention for premium families.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Is there online NEET coaching available for Bellandur residents?',
+    answer:
+      'Yes! Our premium online NEET coaching is ideal for Bellandur families. You get live classes from AIIMS faculty, recorded lectures for flexible viewing, and personalized doubt solving. The Bellandur premium residential community values quality education, and our online platform delivers excellence from your home.',
+  },
+  {
+    question: 'Why is Bellandur suitable for online NEET coaching?',
+    answer:
+      'Bellandur families appreciate premium quality and convenience. Online coaching aligns perfectly - no commute to coaching centers, high internet connectivity in the locality, flexible scheduling around family activities, and world-class AIIMS faculty. Many parents manage busy schedules and prefer home-based learning.',
+  },
+  {
+    question: 'What schools do Bellandur NEET students come from?',
+    answer:
+      'We have students from Inventure Academy, Greenwood High School, Canadian International School, Sri Aurobindo Society School, and other premium institutions. Bellandur attracts affluent families who prioritize quality education, and our coaching complements these premium schools perfectly.',
+  },
+  {
+    question: 'How do you support premium residential families in Bellandur?',
+    answer:
+      'We offer white-glove service - personalized study plans, flexible class timings, premium support team, recorded sessions, and regular progress reports. Our parent portal gives families full visibility. We understand the expectations of premium Bellandur families and deliver accordingly.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Bellandur',
+  description: 'Best NEET Coaching for Bellandur Bangalore - Trusted by Premium Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-bellandur-bangalore',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Bellandur', 'Varthur', 'Marthahalli', 'Gottigere', 'Sunnybrook'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Sparkles className="w-5 h-5 mr-2 text-yellow-400" />
+              Premium Families | AIIMS Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Bellandur</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium Biology Coaching for Bangalore&apos;s Lakeside Residential Community
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Premium NEET coaching for Bellandur, Varthur, Marthahalli & nearby premium areas.
+              Learn from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by affluent
+              families in Bangalore's premier residential localities.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Bellandur%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Sparkles className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Premium</div>
+                <div className="text-sm opacity-80">White Glove</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">680+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Bellandur & Nearby Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for East Bangalore premium residential families
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {bellandurAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Bellandur Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Bellandur Students, Crack NEET with Premium Coaching!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Excellence and convenience for Bangalore's premium families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Bellandur%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-bangalore"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Bangalore NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-sarjapur-road-bangalore"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Sarjapur Road Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-bellandur-bangalore/page.tsx
+++ b/src/app/neet-coaching-bellandur-bangalore/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Bellandur'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Bellandur | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Bellandur Bangalore. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Personalized batches & doubt clearing. Book free demo!',
+  keywords: [
+    'NEET coaching Bellandur',
+    'biology tuition Bellandur',
+    'NEET classes Bellandur Bangalore',
+    'best NEET tutor Bellandur',
+    'medical entrance coaching Bellandur',
+    'NEET preparation Bellandur Lake',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Bellandur | 98% Success Rate | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Bellandur Bangalore. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-bellandur-bangalore`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Bellandur | 98% Success Rate',
+    description:
+      'Join #1 NEET coaching in Bellandur Bangalore. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-bellandur-bangalore`,
+  },
+}
+
+export default function NEETCoachingBellandurPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Bellandur"
+        slug="neet-coaching-bellandur-bangalore"
+        pageTitle="Best NEET Coaching in Bellandur"
+        pageDescription="Join #1 NEET coaching in Bellandur Bangalore. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-bodakdev-ahmedabad/PageContent.tsx
+++ b/src/app/neet-coaching-bodakdev-ahmedabad/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Shield,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const bodakdevAreas = [
+  { name: 'Bodakdev', distance: '0 km', landmark: 'Premium Residential' },
+  { name: 'IIM Ahmedabad', distance: '2 km', landmark: 'Educational Hub' },
+  { name: 'Vastrapur', distance: '3 km', landmark: 'Premium Area' },
+  { name: 'Thaltej', distance: '4 km', landmark: 'IT Park' },
+  { name: 'Satellite', distance: '5 km', landmark: 'Premium Corridor' },
+  { name: 'Akshar Marg', distance: '3 km', landmark: 'Residential Area' },
+  { name: 'Shahibaug', distance: '6 km', landmark: 'Central Ahmedabad' },
+  { name: 'Mahanagar', distance: '7 km', landmark: 'Premium Locality' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Building,
+    title: 'Bodakdev Premium Families Trust Us',
+    description:
+      'Top choice for Bodakdev professional and academic families near IIM. Trusted by doctors, academics, and business families seeking quality NEET coaching.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Proven success with students from Udgam, Ahmedabad International School, GD Goenka, and top Ahmedabad premium institutions.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'Expert Medical Faculty',
+    description:
+      'NEET biology coaching by accomplished medical professionals with 15+ years experience teaching Bodakdev elite families.',
+  },
+  {
+    icon: Star,
+    title: 'Consistent Excellence',
+    description:
+      'Bodakdev students achieve 685+ NEET scores and secure AIIMS, CMC Vellore, and top medical college admissions.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Why do Bodakdev families choose our NEET coaching?',
+    answer:
+      'Bodakdev families value academic excellence and personalized attention. We provide premium online NEET coaching with expert faculty, structured curriculum, and proven results. Our coaching suits professional families near IIM perfectly.',
+  },
+  {
+    question: 'Do you have classes in Bodakdev?',
+    answer:
+      'Our NEET coaching is delivered through premium online live classes. This flexibility is ideal for Bodakdev\'s busy professional families. We offer recorded lectures, comprehensive study material, and regular assessments.',
+  },
+  {
+    question: 'Which schools do your Bodakdev students come from?',
+    answer:
+      'We coach students from Udgam School, Ahmedabad International School, GD Goenka, Vibrant Academy, and other premier Ahmedabad schools in Bodakdev area.',
+  },
+  {
+    question: 'Can I join NEET coaching alongside school exams?',
+    answer:
+      'Absolutely! Our flexible program allows you to balance school and NEET preparation. We offer personalized study schedules and focused support for Bodakdev students managing both.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Bodakdev',
+  description: 'Best NEET Coaching for Bodakdev Ahmedabad - Premium Coaching for IIM Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-bodakdev-ahmedabad',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Ahmedabad',
+    addressRegion: 'Gujarat',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Bodakdev', 'Vastrapur', 'Thaltej', 'IIM Area', 'Ahmedabad'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Building className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by IIM Area Families | Expert Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Bodakdev Ahmedabad</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium NEET Coaching for Professional & Academic Families
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Expert NEET coaching for Bodakdev, IIM area, and surrounding premium zones. Learn from
+              accomplished medical faculty trusted by <strong>academics and professional families</strong>. Premium
+              online classes with recorded lectures and proven 685+ NEET results.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Bodakdev%20Ahmedabad%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Premium</div>
+                <div className="text-sm opacity-80">Locality</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Star className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">685+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Bodakdev & Premium Ahmedabad Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Ahmedabad's premium residential zones
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {bodakdevAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Bodakdev Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Bodakdev Students, Excel in NEET!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium NEET coaching for Bodakdev's finest families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Bodakdev%20Ahmedabad%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-ahmedabad"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Ahmedabad NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-sg-highway-ahmedabad"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              SG Highway Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-bodakdev-ahmedabad/page.tsx
+++ b/src/app/neet-coaching-bodakdev-ahmedabad/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Bodakdev'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Bodakdev Ahmedabad | Premium Residential | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Bodakdev, Ahmedabad. Expert faculty, proven 98% success rate, 695/720 top score. Premium coaching near IIM. Book free demo!',
+  keywords: [
+    'NEET coaching Bodakdev',
+    'biology tuition Bodakdev Ahmedabad',
+    'NEET classes Bodakdev',
+    'best NEET tutor near IIM',
+    'medical entrance Bodakdev',
+    'NEET preparation Bodakdev',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Bodakdev Ahmedabad | Premium Residential | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Bodakdev, Ahmedabad. Expert faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-bodakdev-ahmedabad`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Bodakdev Ahmedabad | Premium',
+    description:
+      'Join #1 NEET coaching in Bodakdev, Ahmedabad. Expert faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-bodakdev-ahmedabad`,
+  },
+}
+
+export default function NEETCoachingBodakdevAhmedabadPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Bodakdev"
+        slug="neet-coaching-bodakdev-ahmedabad"
+        pageTitle="Best NEET Coaching in Bodakdev"
+        pageDescription="Join #1 NEET coaching in Bodakdev, Ahmedabad. Expert faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-c-scheme-jaipur/PageContent.tsx
+++ b/src/app/neet-coaching-c-scheme-jaipur/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Shield,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const cSchemeAreas = [
+  { name: 'C-Scheme', distance: '0 km', landmark: 'Tier 1 Premium' },
+  { name: 'MI Road', distance: '2 km', landmark: 'Central Business' },
+  { name: 'Malviya Nagar', distance: '4 km', landmark: 'Premium Residential' },
+  { name: 'Vaishali Nagar', distance: '5 km', landmark: 'Educational Hub' },
+  { name: 'Bani Park', distance: '3 km', landmark: 'Heritage Area' },
+  { name: 'Jai Singh Highway', distance: '6 km', landmark: 'Business District' },
+  { name: 'Ashok Nagar', distance: '7 km', landmark: 'Residential Zone' },
+  { name: 'Adarsh Nagar', distance: '5 km', landmark: 'Residential Area' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Building,
+    title: 'C-Scheme Industrialist Families Trust Us',
+    description:
+      'Top choice for Tier 1 C-Scheme industrialist and professional families. Trusted by business elite seeking premium NEET coaching.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Proven success with students from Rajkiya Vidyapith, Maharaja College, D.A.V. Public School, and top Jaipur institutions.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'Expert Medical Faculty',
+    description:
+      'NEET biology coaching by accomplished medical professionals with 15+ years experience teaching C-Scheme elite families.',
+  },
+  {
+    icon: Star,
+    title: 'Top NEET Results',
+    description:
+      'C-Scheme students achieve 685+ NEET scores and secure AIIMS, CMC Vellore, and prestigious medical college seats.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Why do C-Scheme families choose our NEET coaching?',
+    answer:
+      'C-Scheme families value excellence, heritage, and results. We provide premium NEET coaching with expert faculty, rigorous curriculum, and proven success rate matching Tier 1 standards.',
+  },
+  {
+    question: 'Do you have classes in C-Scheme Jaipur?',
+    answer:
+      'Our NEET coaching is delivered through premium online live classes. This flexibility suits busy C-Scheme professionals. We provide recorded lectures, comprehensive material, and regular assessments.',
+  },
+  {
+    question: 'Which schools do your C-Scheme students attend?',
+    answer:
+      'We coach students from Rajkiya Vidyapith, Maharaja College, D.A.V. Public School, St. Xavier\'s, and other premier Jaipur institutions.',
+  },
+  {
+    question: 'How is your coaching customized for C-Scheme students?',
+    answer:
+      'We provide personalized attention with customized study plans. Regular one-on-one sessions, progress tracking, and targeted support ensure each C-Scheme student achieves their best potential.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching C-Scheme',
+  description: 'Best NEET Coaching for C-Scheme Jaipur - Tier 1 Premium Coaching for Industrialist Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-c-scheme-jaipur',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Jaipur',
+    addressRegion: 'Rajasthan',
+    addressCountry: 'IN',
+  },
+  areaServed: ['C-Scheme', 'MI Road', 'Malviya Nagar', 'Vaishali Nagar', 'Jaipur'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Building className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by C-Scheme Industrialists | Expert Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">C-Scheme Jaipur</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Tier 1 Premium NEET Coaching for Jaipur's Elite
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Exclusive NEET coaching for C-Scheme, MI Road, and Jaipur's premium areas. Learn from
+              accomplished medical faculty trusted by <strong>industrialists and established families</strong>. Premium
+              online classes with recorded lectures and proven 685+ NEET results.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20C-Scheme%20Jaipur%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Tier 1</div>
+                <div className="text-sm opacity-80">Premium</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Star className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">685+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              C-Scheme & Premium Jaipur Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Jaipur's elite communities
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {cSchemeAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why C-Scheme Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              C-Scheme Elite, Master NEET with Distinction!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Tier 1 premium NEET coaching for Jaipur's finest families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20C-Scheme%20Jaipur%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-jaipur"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Jaipur NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-malviya-nagar-jaipur"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Malviya Nagar Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-c-scheme-jaipur/page.tsx
+++ b/src/app/neet-coaching-c-scheme-jaipur/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'C-Scheme'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in C-Scheme Jaipur | Tier 1 Premium | Cerebrum',
+  description:
+    'Join #1 NEET coaching in C-Scheme, Jaipur. Expert faculty, proven 98% success rate, 695/720 top score. Premium coaching for industrialist families. Book free demo!',
+  keywords: [
+    'NEET coaching C-Scheme',
+    'biology tuition C-Scheme Jaipur',
+    'NEET classes C-Scheme',
+    'best NEET tutor MI Road',
+    'medical entrance C-Scheme',
+    'NEET preparation Tier 1 premium Jaipur',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in C-Scheme Jaipur | Tier 1 Premium | Cerebrum',
+    description:
+      'Join #1 NEET coaching in C-Scheme, Jaipur. Expert faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-c-scheme-jaipur`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in C-Scheme Jaipur | Tier 1 Premium',
+    description:
+      'Join #1 NEET coaching in C-Scheme, Jaipur. Expert faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-c-scheme-jaipur`,
+  },
+}
+
+export default function NEETCoachingCSchemeJaipurPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="C-Scheme"
+        slug="neet-coaching-c-scheme-jaipur"
+        pageTitle="Best NEET Coaching in C-Scheme"
+        pageDescription="Join #1 NEET coaching in C-Scheme, Jaipur. Expert faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-colaba-mumbai/PageContent.tsx
+++ b/src/app/neet-coaching-colaba-mumbai/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Gem,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const colabaAreas = [
+  { name: 'Colaba', distance: '19 km', landmark: 'South Mumbai Peninsula' },
+  { name: 'Navy Nagar', distance: '19 km', landmark: 'Upscale Naval Officers' },
+  { name: 'Cuffe Parade', distance: '18 km', landmark: 'Iconic Waterfront' },
+  { name: 'Fort', distance: '17 km', landmark: 'Business District' },
+  { name: 'Kala Ghoda', distance: '18 km', landmark: 'Arts & Culture' },
+  { name: 'Girgaum', distance: '16 km', landmark: 'Historic Area' },
+  { name: 'Malabar Hill', distance: '15 km', landmark: 'Premium Residential' },
+  { name: 'Worli', distance: '17 km', landmark: 'Premium Area' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Gem,
+    title: 'South Mumbai Elite Specialist',
+    description:
+      'Colaba is the most prestigious South Mumbai locality. We specialize in coaching for affluent Navy families and high-income households in South Mumbai.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Proven track record with students from Cathedral School, Bombay Scottish, and elite institutions in South Mumbai.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'AIIMS Faculty',
+    description:
+      'Dr. Shekhar C Singh, AIIMS Alumnus with 15+ years experience coaching highly motivated students from South Mumbai\'s premium families.',
+  },
+  {
+    icon: Star,
+    title: 'Top Results',
+    description:
+      'Colaba and Navy Nagar students scored 695+ in NEET with multiple AIIMS and prestigious medical college admissions.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Do you have a coaching center in Colaba or South Mumbai?',
+    answer:
+      'Our main center is in Greater Noida. For Colaba and South Mumbai residents, we offer exclusive live online NEET classes with personalized attention. Many affluent South Mumbai families prefer online coaching for convenience and security. Our comprehensive material and recorded lectures ensure uninterrupted preparation.',
+  },
+  {
+    question: 'How do you understand Navy families\' needs?',
+    answer:
+      'Navy families in Colaba and Navy Nagar value discipline, structure, and excellence. We mirror these values through fixed schedules, rigorous testing, detailed progress reports, and result-oriented teaching. Our approach is tailored for military and naval families.',
+  },
+  {
+    question: 'Which schools do your Colaba students attend?',
+    answer:
+      'We have students from Cathedral School Mumbai, Bombay Scottish, Jamnabai Narsee, and other elite institutions in South Mumbai. The academically rigorous environment of these schools aligns perfectly with our NEET preparation methodology.',
+  },
+  {
+    question: 'Is NEET coaching suitable for internationally mobile families?',
+    answer:
+      'Yes! Many Colaba families have international postings. Our flexible online platform accommodates travel. Students can attend live classes when available and catch up via recorded sessions. Progress reports keep families informed despite geographical distance.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Colaba',
+  description: 'Best NEET Coaching for Colaba South Mumbai - Elite naval families coaching',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-colaba-mumbai',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Colaba', 'Navy Nagar', 'Cuffe Parade', 'Fort', 'Malabar Hill'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Gem className="w-5 h-5 mr-2 text-yellow-400" />
+              Elite South Mumbai Coaching | AIIMS Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Colaba</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium Biology Coaching for South Mumbai&apos;s Most Prestigious Locality
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Exclusive NEET coaching for Colaba, Navy Nagar, and South Mumbai elite families. Learn
+              from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by affluent South
+              Mumbai families.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Colaba%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Gem className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Elite</div>
+                <div className="text-sm opacity-80">Naval Families</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">695+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Colaba & South Mumbai Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for South Mumbai&apos;s elite and affluent residents
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {colabaAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Colaba Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Colaba Elite Families, Secure Your Medical Future!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium NEET coaching for South Mumbai&apos;s most prestigious locality
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Colaba%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-mumbai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Mumbai NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-fort-mumbai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Fort NEET Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-colaba-mumbai/page.tsx
+++ b/src/app/neet-coaching-colaba-mumbai/page.tsx
@@ -1,0 +1,69 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Colaba'
+const city = 'Mumbai'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: `${locality}, ${city}`,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Colaba Mumbai | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Colaba, South Mumbai. Expert AIIMS faculty, 98% success rate. Navy Nagar, Cuffe Parade. Premium online coaching. Book free demo!',
+  keywords: [
+    'NEET coaching Colaba',
+    'biology tuition Colaba',
+    'NEET classes South Mumbai',
+    'best NEET tutor Navy Nagar',
+    'medical entrance Cuffe Parade',
+    'NEET preparation Colaba',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Colaba Mumbai | 98% Success Rate | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Colaba, South Mumbai. Expert AIIMS faculty, 98% success rate. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-colaba-mumbai`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Colaba Mumbai | 98% Success Rate',
+    description:
+      'Join #1 NEET coaching in Colaba, South Mumbai. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-colaba-mumbai`,
+  },
+}
+
+export default function NEETCoachingColabaMumbaiPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Colaba"
+        slug="neet-coaching-colaba-mumbai"
+        pageTitle="Best NEET Coaching in Colaba"
+        pageDescription="Join #1 NEET coaching in Colaba, South Mumbai. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-electronic-city-bangalore/PageContent.tsx
+++ b/src/app/neet-coaching-electronic-city-bangalore/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Zap,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const electronicCityAreas = [
+  { name: 'Electronic City', distance: '15 km', landmark: 'Infosys Campus' },
+  { name: 'Bannerghatta Road', distance: '12 km', landmark: 'Commercial Hub' },
+  { name: 'Bommanahalli', distance: '10 km', landmark: 'Tech Corridor' },
+  { name: 'Domlur', distance: '18 km', landmark: 'Business District' },
+  { name: 'Koramangala', distance: '20 km', landmark: 'Startup Hub' },
+  { name: 'Rachenahalli', distance: '8 km', landmark: 'Residential Area' },
+  { name: 'Chikakannalli', distance: '7 km', landmark: 'Gated Communities' },
+  { name: 'Agara', distance: '11 km', landmark: 'Premium Locality' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Zap,
+    title: 'Infosys Families & Tech Professionals',
+    description:
+      'Trusted by Infosys employees and IT professionals living in Electronic City corporate housing.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Proven track record with students from Arete, DPS Bangalore South, Canadian International, and premier tech-hub schools.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'AIIMS Faculty & Flexible Learning',
+    description:
+      'Dr. Shekhar C Singh, AIIMS Alumnus with 15+ years experience. Online classes adapted for corporate families.',
+  },
+  {
+    icon: Star,
+    title: 'Specialized Infosys Family Programs',
+    description:
+      'Students score 680+, with special support for families managing work-life balance and frequent relocations.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Do you have coaching centers near Electronic City Infosys campus?',
+    answer:
+      'Our main center is in Greater Noida. For Electronic City Infosys professionals and families, we provide premium live online NEET classes that can be accessed from anywhere. This is ideal for Infosys employees whose roles may require flexibility or relocation. You get world-class AIIMS faculty coaching without the burden of physical commute.',
+  },
+  {
+    question: 'Why choose online NEET coaching for Infosys families?',
+    answer:
+      'Infosys families often have demanding schedules and may face transfers. Online coaching provides continuity - if your family relocates, your child continues uninterrupted learning. Our recorded lectures, flexible timings, and 24/7 doubt solving are perfect for busy corporate families. Parents get regular performance reports.',
+  },
+  {
+    question: 'What schools do Electronic City students attend?',
+    answer:
+      'We have students from Arete School, DPS Bangalore South, Canadian International School, Inventure Academy, Sri Aurobindo Society School, and Greenwood High School. Many Infosys employees choose these premium schools, and we specialize in supporting their NEET aspirations.',
+  },
+  {
+    question: 'How do you accommodate Infosys relocation schedules?',
+    answer:
+      'Infosys frequently transfers employees. Our online platform ensures your child can continue preparation from any city. We provide recorded classes for continuity, flexible test schedules, and a comprehensive learner dashboard. Many students have studied while their families relocated to other cities.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Electronic City',
+  description: 'Best NEET Coaching for Electronic City Bangalore - Trusted by Infosys Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-electronic-city-bangalore',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Electronic City', 'Bannerghatta Road', 'Bommanahalli', 'Domlur', 'Koramangala'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Zap className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Infosys Families | AIIMS Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Electronic City</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium Biology Coaching for Bangalore&apos;s Infosys Hub
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Premium NEET coaching for Electronic City, Bannerghatta, Bommanahalli & nearby areas.
+              Learn from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by Infosys
+              professionals and corporate families.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Electronic%20City%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Zap className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Online</div>
+                <div className="text-sm opacity-80">Classes 24/7</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">680+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Electronic City & Nearby Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for South Bangalore IT professionals and families
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {electronicCityAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Electronic City Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Electronic City Students, Crack NEET Online!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium NEET coaching with flexibility for corporate families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Electronic%20City%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-bangalore"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Bangalore NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-sarjapur-road-bangalore"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Sarjapur Road Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-electronic-city-bangalore/page.tsx
+++ b/src/app/neet-coaching-electronic-city-bangalore/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Electronic City'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Electronic City | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Electronic City Bangalore. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Personalized batches & doubt clearing. Book free demo!',
+  keywords: [
+    'NEET coaching Electronic City',
+    'biology tuition Electronic City',
+    'NEET classes Electronic City Bangalore',
+    'best NEET tutor Electronic City',
+    'medical entrance coaching Electronic City',
+    'NEET preparation South Bangalore',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Electronic City | 98% Success Rate | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Electronic City Bangalore. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-electronic-city-bangalore`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Electronic City | 98% Success Rate',
+    description:
+      'Join #1 NEET coaching in Electronic City Bangalore. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-electronic-city-bangalore`,
+  },
+}
+
+export default function NEETCoachingElectronicCityPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Electronic City"
+        slug="neet-coaching-electronic-city-bangalore"
+        pageTitle="Best NEET Coaching in Electronic City"
+        pageDescription="Join #1 NEET coaching in Electronic City Bangalore. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-gachibowli-hyderabad/PageContent.tsx
+++ b/src/app/neet-coaching-gachibowli-hyderabad/PageContent.tsx
@@ -1,0 +1,402 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Rocket,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const gachibowliAreas = [
+{ name: 'Gachibowli', distance: '16 km', landmark: 'IIIT Vicinity' },
+  { name: 'ISB Area', distance: '15 km', landmark: 'Business School' },
+  { name: 'Nanakramguda', distance: '14 km', landmark: 'Tech Corridor' },
+  { name: 'Kondapur', distance: '17 km', landmark: 'Corporate Zone' },
+  { name: 'Madhapur', distance: '18 km', landmark: 'Tech Hub' },
+  { name: 'Hitec City', distance: '19 km', landmark: 'IT Zone' },
+  { name: 'Shilparamam', distance: '20 km', landmark: 'Mixed Use' },
+  { name: 'Hafeezpet', distance: '13 km', landmark: 'Tech Zone' }
+]
+
+const whyChooseUs = [
+
+]
+
+const faqs = [
+{
+    question: 'Why IIIT and ISB families choose our coaching?',
+    answer:
+      'Academic families value rigorous, research-based education. Our NEET coaching emphasizes conceptual clarity, intellectual rigor, and competitive preparation. Perfect fit for families with academic backgrounds.',
+  },
+  {
+    question: 'How is your coaching suitable for ISB families?',
+    answer:
+      'ISB families have global perspective. Our coaching incorporates international best practices, research-backed pedagogy, and critical thinking approach that ISB families value.',
+  },
+  {
+    question: 'What schools do Gachibowli academic students attend?',
+    answer:
+      'We have students from Oakridge, international schools, and academic-focused institutions. Gachibowli attracts intellectually ambitious families.',
+  },
+  {
+    question: 'Do you prepare for medical competitive exams and research?',
+    answer:
+      'Yes! Beyond NEET scores, we emphasize conceptual understanding, research interests, and critical thinking that medical schools value. Perfect for families aiming for research-oriented medical careers.',
+  }
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Gachibowli',
+  description: 'Best NEET Coaching for Gachibowli Hyderabad - Trusted by Premium Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-gachibowli-hyderabad',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Gachibowli', 'ISB Area', 'Nanakramguda', 'Kondapur', 'Madhapur'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ { __html: JSON.stringify(faqSchema) } }
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ { __html: JSON.stringify(localBusinessSchema) } }
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Rocket className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by IIIT & ISB Families
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Gachibowli</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              ISB & IIIT Tech Hub
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Premium NEET coaching for Gachibowli, IIIT area, ISB vicinity & nearby areas. Learn from Dr. Shekhar C Singh, AIIMS Alumnus - trusted by academic and tech families.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Gachibowli%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Rocket className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Tech</div>
+                <div className="text-sm opacity-80">Integration</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">680+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Gachibowli & Nearby Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Hyderabad premium families
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {gachibowliAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={ { animationDelay: `${index * 50}ms` } }
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Gachibowli Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={ { animationDelay: `${index * 100}ms` } }
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={ { animationDelay: `${index * 100}ms` } }
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Gachibowli Students, Excel in NEET!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium coaching for academic families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Gachibowli%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-hyderabad"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Hyderabad NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-kondapur-hyderabad"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Kondapur Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-gachibowli-hyderabad/page.tsx
+++ b/src/app/neet-coaching-gachibowli-hyderabad/page.tsx
@@ -1,524 +1,68 @@
-'use client'
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
 
-import { motion } from 'framer-motion'
-import {
-  MapPin,
-  Users,
-  Trophy,
-  Star,
-  CheckCircle,
-  Award,
-  BookOpen,
-  Clock,
-  Video,
-  MessageCircle,
-  Play,
-  ArrowRight,
-  GraduationCap,
-  Building,
-  Cpu,
-} from 'lucide-react'
-import { Button } from '@/components/ui/Button'
-import Link from 'next/link'
-import { CitySchema } from '@/components/seo/CitySchema'
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Gachibowli'
 
-const gachibowliLocalities = [
-  {
-    name: 'Gachibowli',
-    slug: 'gachibowli',
-    students: '280+',
-    highlight: 'IT Hub Center',
-    priority: 'high',
-  },
-  {
-    name: 'Financial District',
-    slug: 'financial-district',
-    students: '150+',
-    highlight: 'Corporate Hub',
-    priority: 'high',
-  },
-  {
-    name: 'Nanakramguda',
-    slug: 'nanakramguda',
-    students: '120+',
-    highlight: 'IT Corridor',
-    priority: 'high',
-  },
-  {
-    name: 'Kondapur',
-    slug: 'kondapur',
-    students: '180+',
-    highlight: 'Tech Residential',
-    priority: 'high',
-  },
-  {
-    name: 'Manikonda',
-    slug: 'manikonda',
-    students: '140+',
-    highlight: 'Growing IT Hub',
-    priority: 'high',
-  },
-  {
-    name: 'Gopanpally',
-    slug: 'gopanpally',
-    students: '95+',
-    highlight: 'Biodiversity Junction',
-    priority: 'medium',
-  },
-  {
-    name: 'Tellapur',
-    slug: 'tellapur',
-    students: '85+',
-    highlight: 'Extended IT Zone',
-    priority: 'medium',
-  },
-  {
-    name: 'Narsingi',
-    slug: 'narsingi',
-    students: '90+',
-    highlight: 'Premium Residential',
-    priority: 'medium',
-  },
-]
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
 
-const features = [
-  {
-    icon: Video,
-    title: 'Live Interactive Classes',
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Gachibowli | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Gachibowli Hyderabad. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Personalized batches & doubt clearing. Book free demo!',
+  keywords: [
+    'NEET coaching Gachibowli',
+    'biology tuition Gachibowli',
+    'NEET classes Gachibowli Hyderabad',
+    'best NEET tutor Gachibowli',
+    'medical entrance coaching Gachibowli',
+    'NEET preparation Hyderabad',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Gachibowli | 98% Success Rate | Cerebrum',
     description:
-      "Premium online coaching for IT professionals' children. No traffic from Gachibowli. Study from home.",
+      'Join #1 NEET coaching in Gachibowli Hyderabad. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-gachibowli-hyderabad`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
   },
-  {
-    icon: Users,
-    title: 'Elite Small Batches (10-15)',
-    description: 'Exclusive batches with personalized attention perfect for busy IT families.',
-  },
-  {
-    icon: Award,
-    title: 'AIIMS Trained Faculty',
-    description: 'Expert doctors and teachers from premier medical institutions.',
-  },
-  {
-    icon: BookOpen,
-    title: 'Complete Premium Package',
-    description: 'NCERT mastery, advanced materials, unlimited doubt sessions included.',
-  },
-  {
-    icon: Clock,
-    title: 'Flexible IT-Friendly Timings',
-    description: 'Batches designed for IT family schedules - weekend and evening options.',
-  },
-  {
-    icon: Cpu,
-    title: 'Tech-Forward Learning',
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Gachibowli | 98% Success Rate',
     description:
-      'Digital-native learning platform. App access, recorded lectures, AI-powered practice.',
+      'Join #1 NEET coaching in Gachibowli Hyderabad. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
   },
-]
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-gachibowli-hyderabad`,
+  },
+}
 
-const successMetrics = [
-  { label: 'Success Rate', value: '94.2%', icon: Trophy },
-  { label: 'Top Score 2024', value: '360', icon: Star },
-  { label: 'IT Hub Students', value: '950+', icon: Users },
-  { label: 'Premium Schools', value: '15+', icon: GraduationCap },
-]
-
-const faqs = [
-  {
-    question: 'Why do Gachibowli IT families choose online NEET coaching?',
-    answer:
-      "Gachibowli's IT professionals understand the value of quality online education. With demanding work schedules and traffic, online coaching saves 2-3 hours daily. Our tech-forward platform provides the same quality as physical coaching with superior flexibility. 94.2% success rate proves effectiveness.",
-  },
-  {
-    question: 'Which areas in Gachibowli do you serve?',
-    answer:
-      'We serve all Gachibowli and Financial District localities including Nanakramguda, Kondapur, Manikonda, Gopanpally, Tellapur, Narsingi, and all surrounding IT corridor areas. Perfect for families in DLF, My Home, Aparna complexes.',
-  },
-  {
-    question: 'What is the fee for NEET coaching in Gachibowli?',
-    answer:
-      "Our complete NEET Biology course ranges from Rs 24,000 to Rs 68,000 per year. For Gachibowli's IT families, this represents excellent value - premium education at a fraction of physical coaching costs, with zero commute time.",
-  },
-  {
-    question: "How does this fit with IT professional parents' schedules?",
-    answer:
-      'We offer multiple batch timings including early morning, evening, and weekend intensive options. Parents can monitor progress through our app. Recorded lectures allow students to catch up if they miss a class.',
-  },
-  {
-    question: 'Do you have batches for international school students?',
-    answer:
-      'Yes! Many Gachibowli students attend Oakridge, ISB Mohali, and other international schools. We have specialized IB, IGCSE, and Cambridge batches that bridge international curriculum with NEET requirements.',
-  },
-  {
-    question: 'What medical colleges can Gachibowli students target?',
-    answer:
-      'With proper NEET preparation, students can target Osmania Medical College, Gandhi Medical College, NIMS, and all-India institutes like AIIMS and JIPMER. Many IT families also consider private medical colleges as backup.',
-  },
-]
-
-const premiumSchools = [
-  'Oakridge International',
-  'Delhi Public School',
-  'Meridian School',
-  'Sreenidhi International',
-  'Chirec International',
-  'Gitanjali Devashray',
-  'Silver Oaks International',
-  'Glendale Academy',
-  'Indus International',
-  'NASR School',
-]
-
-const whyGachibowli = [
-  {
-    icon: Cpu,
-    title: 'Built for IT Families',
-    description:
-      'Tech-forward platform designed for digital-native families. App-based learning, AI practice, progress tracking.',
-  },
-  {
-    icon: Building,
-    title: 'Zero Commute Premium',
-    description:
-      'Skip the ORR traffic. Get world-class coaching from your Gachibowli apartment or villa.',
-  },
-  {
-    icon: GraduationCap,
-    title: 'Flexible for Busy Schedules',
-    description:
-      'Multiple batch timings, recorded lectures, weekend intensives - designed for IT family lifestyles.',
-  },
-]
-
-export default function NeetCoachingGachibowliPage() {
-  const handleDemoBooking = () => {
-    if (typeof window !== 'undefined' && (window as any).gtag) {
-      ;(window as any).gtag('event', 'demo_booking_gachibowli', {
-        event_category: 'conversion',
-        event_label: 'neet_coaching_gachibowli_page',
-        value: 1,
-      })
-    }
-  }
-
+export default function NEETCoachingGachibowliPage() {
   return (
-    <div className="min-h-screen">
-      <CitySchema
-        cityName="Gachibowli"
-        citySlug="gachibowli-hyderabad"
-        state="Telangana"
-        localities={gachibowliLocalities.map((l) => l.name)}
-        faqs={faqs}
-        studentCount="950"
-        coordinates={{ lat: '17.4401', lng: '78.3489' }}
+    <>
+      <LocalitySchema
+        locality="Gachibowli"
+        slug="neet-coaching-gachibowli-hyderabad"
+        pageTitle="Best NEET Coaching in Gachibowli"
+        pageDescription="Join #1 NEET coaching in Gachibowli Hyderabad. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
       />
-      {/* Hero Section */}
-      <section className="relative bg-gradient-to-br from-cyan-900 via-cyan-700 to-blue-800 text-white py-20 overflow-hidden">
-        <div className="absolute inset-0 bg-black/20" />
-        <div className="relative max-w-7xl mx-auto px-4">
-          <motion.div
-            className="text-center max-w-4xl mx-auto"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8 }}
-          >
-            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
-              <MapPin className="w-5 h-5 mr-2" />
-              Hyderabad IT Hub | Premium NEET Coaching for Tech Families
-            </div>
-
-            <h1 className="text-4xl md:text-6xl font-bold mb-6">
-              Best <span className="text-yellow-300">NEET Coaching in Gachibowli</span>, Hyderabad
-            </h1>
-
-            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
-              Gachibowli | Financial District | Kondapur | Nanakramguda | Manikonda
-            </h2>
-
-            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
-              Premium NEET Biology coaching for IT families. 94.2% success rate, AIIMS faculty,
-              tech-forward platform. Zero ORR traffic. Join 950+ students from Gachibowli IT
-              corridor.
-            </p>
-
-            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
-              <Link href="/demo-booking">
-                <Button
-                  variant="secondary"
-                  size="xl"
-                  onClick={handleDemoBooking}
-                  className="bg-yellow-500 text-black hover:bg-yellow-400"
-                >
-                  <Play className="w-5 h-5 mr-2" />
-                  Book Free Demo Class
-                </Button>
-              </Link>
-
-              <Link href="/courses">
-                <Button
-                  variant="outline"
-                  size="xl"
-                  className="border-white text-white hover:bg-white hover:text-cyan-900"
-                >
-                  <BookOpen className="w-5 h-5 mr-2" />
-                  View Premium Programs
-                </Button>
-              </Link>
-            </div>
-
-            <div className="grid md:grid-cols-4 gap-6 max-w-4xl mx-auto">
-              {successMetrics.map((metric, index) => (
-                <motion.div
-                  key={metric.label}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.6, delay: 0.2 + index * 0.1 }}
-                  className="bg-white/10 backdrop-blur-sm rounded-xl p-6"
-                >
-                  <metric.icon className="w-8 h-8 mx-auto mb-2 text-yellow-300" />
-                  <div className="text-2xl font-bold">{metric.value}</div>
-                  <div className="text-sm opacity-80">{metric.label}</div>
-                </motion.div>
-              ))}
-            </div>
-          </motion.div>
-        </div>
-      </section>
-
-      {/* Localities Section */}
-      <section className="py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div
-            className="text-center mb-16"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-          >
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              NEET Coaching Across Gachibowli IT Corridor
-            </h2>
-          </motion.div>
-
-          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {gachibowliLocalities.map((locality, index) => (
-              <motion.div
-                key={locality.slug}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.4, delay: index * 0.05 }}
-                viewport={{ once: true }}
-              >
-                <div
-                  className={`bg-white rounded-xl shadow-lg p-6 hover:shadow-xl transition-all hover:-translate-y-1 cursor-pointer ${
-                    locality.priority === 'high' ? 'ring-2 ring-cyan-600' : ''
-                  }`}
-                >
-                  <div className="flex items-center justify-between mb-2">
-                    <h3 className="text-lg font-bold text-gray-900">{locality.name}</h3>
-                    <MapPin className="w-5 h-5 text-cyan-600" />
-                  </div>
-                  <div className="text-2xl font-bold text-cyan-600 mb-1">{locality.students}</div>
-                  <div className="text-sm text-gray-500">{locality.highlight}</div>
-                  {locality.priority === 'high' && (
-                    <div className="mt-2 inline-flex items-center text-xs bg-cyan-100 text-cyan-700 px-2 py-1 rounded-full">
-                      <Star className="w-3 h-3 mr-1" />
-                      IT Hub Area
-                    </div>
-                  )}
-                </div>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Why Gachibowli Section */}
-      <section className="py-20 bg-white">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div
-            className="text-center mb-16"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-          >
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              Why IT Families Choose Cerebrum
-            </h2>
-          </motion.div>
-
-          <div className="grid md:grid-cols-3 gap-8 mb-16">
-            {whyGachibowli.map((item, index) => (
-              <motion.div
-                key={item.title}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-cyan-50 rounded-xl p-8 border border-cyan-100"
-              >
-                <item.icon className="w-12 h-12 text-cyan-600 mb-4" />
-                <h3 className="text-xl font-bold text-gray-900 mb-2">{item.title}</h3>
-                <p className="text-gray-600">{item.description}</p>
-              </motion.div>
-            ))}
-          </div>
-
-          <div className="bg-gray-50 rounded-2xl p-8">
-            <h3 className="text-2xl font-bold text-gray-900 mb-6 text-center">
-              Students from These Premium Schools Trust Us
-            </h3>
-            <div className="flex flex-wrap justify-center gap-4">
-              {premiumSchools.map((school, index) => (
-                <motion.span
-                  key={school}
-                  initial={{ opacity: 0, scale: 0.8 }}
-                  whileInView={{ opacity: 1, scale: 1 }}
-                  transition={{ duration: 0.4, delay: index * 0.05 }}
-                  viewport={{ once: true }}
-                  className="bg-white text-gray-700 px-4 py-2 rounded-full font-medium shadow-sm"
-                >
-                  {school}
-                </motion.span>
-              ))}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Features Section */}
-      <section className="py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div
-            className="text-center mb-16"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-          >
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              Premium NEET Biology Coaching Features
-            </h2>
-          </motion.div>
-
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {features.map((feature, index) => (
-              <motion.div
-                key={feature.title}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-white rounded-xl p-8 shadow-lg"
-              >
-                <feature.icon className="w-12 h-12 text-cyan-600 mb-4" />
-                <h3 className="text-xl font-bold text-gray-900 mb-2">{feature.title}</h3>
-                <p className="text-gray-600">{feature.description}</p>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* FAQs Section */}
-      <section className="py-20 bg-white">
-        <div className="max-w-4xl mx-auto px-4">
-          <motion.div
-            className="text-center mb-16"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-          >
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              FAQs - NEET Coaching Gachibowli
-            </h2>
-          </motion.div>
-
-          <div className="space-y-6">
-            {faqs.map((faq, index) => (
-              <motion.div
-                key={faq.question}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-gray-50 rounded-xl p-8"
-              >
-                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
-                  <MessageCircle className="w-6 h-6 mr-3 text-cyan-600 flex-shrink-0 mt-1" />
-                  {faq.question}
-                </h3>
-                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* CTA Section */}
-      <section className="py-20 bg-gradient-to-r from-cyan-600 via-cyan-600 to-blue-700 text-white">
-        <div className="max-w-4xl mx-auto px-4 text-center">
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-          >
-            <h2 className="text-3xl md:text-5xl font-bold mb-6">
-              Join Gachibowli&apos;s Tech-Savvy NEET Aspirants
-            </h2>
-            <p className="text-xl md:text-2xl mb-8 opacity-90">
-              94.2% success rate, AIIMS faculty, tech-forward platform. Built for IT families!
-            </p>
-
-            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
-              <Link href="/demo-booking">
-                <Button
-                  variant="secondary"
-                  size="xl"
-                  onClick={handleDemoBooking}
-                  className="bg-yellow-500 text-black hover:bg-yellow-400"
-                >
-                  <Play className="w-5 h-5 mr-2" />
-                  Book Free Demo Class
-                </Button>
-              </Link>
-
-              <Link href="/enrollment">
-                <Button
-                  variant="outline"
-                  size="xl"
-                  className="border-white text-white hover:bg-white hover:text-cyan-600"
-                >
-                  <ArrowRight className="w-5 h-5 mr-2" />
-                  Enroll Now
-                </Button>
-              </Link>
-            </div>
-
-            <div className="grid md:grid-cols-4 gap-6 max-w-3xl mx-auto text-sm">
-              <div className="flex items-center justify-center">
-                <CheckCircle className="w-4 h-4 mr-2" />
-                <span>IT Corridor</span>
-              </div>
-              <div className="flex items-center justify-center">
-                <CheckCircle className="w-4 h-4 mr-2" />
-                <span>Live Classes</span>
-              </div>
-              <div className="flex items-center justify-center">
-                <CheckCircle className="w-4 h-4 mr-2" />
-                <span>AIIMS Faculty</span>
-              </div>
-              <div className="flex items-center justify-center">
-                <CheckCircle className="w-4 h-4 mr-2" />
-                <span>Tech Platform</span>
-              </div>
-            </div>
-          </motion.div>
-        </div>
-      </section>
-    </div>
+      <PageContent />
+    </>
   )
 }

--- a/src/app/neet-coaching-gomti-nagar-lucknow/PageContent.tsx
+++ b/src/app/neet-coaching-gomti-nagar-lucknow/PageContent.tsx
@@ -1,0 +1,163 @@
+'use client'
+import { useState, useEffect, useRef } from 'react'
+import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield } from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        setIsVisible(true)
+        observer.unobserve(element)
+      }
+    }, { threshold })
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+  return { ref, isVisible }
+}
+
+const areas = [
+  { name: 'Gomti Nagar', distance: '0 km', landmark: 'Premium Residential' },
+  { name: 'Vaishali Nagar', distance: '3 km', landmark: 'Educational Hub' },
+  { name: 'C-Scheme', distance: '4 km', landmark: 'Tier 1 Premium' },
+  { name: 'Bani Park', distance: '5 km', landmark: 'Heritage Area' },
+  { name: 'MI Road', distance: '6 km', landmark: 'Central Business' },
+  { name: 'Adarsh Nagar', distance: '4 km', landmark: 'Residential Zone' },
+  { name: 'Jawahar Lal Nehru Marg', distance: '7 km', landmark: 'Premium Area' },
+  { name: 'Raja Park', distance: '8 km', landmark: 'Upscale Locality' },
+]
+
+const whyChooseUs = [
+  { icon: Building, title: 'Gomti Nagar Professional Families Trust Us', description: 'Top choice for Gomti Nagar professionals and academics. Trusted by doctors, engineers, and business families.' },
+  { icon: Target, title: '500+ NEET Selections', description: 'Proven success with students from premier Lucknow institutions.' },
+  { icon: GraduationCap, title: 'Expert Medical Faculty', description: 'NEET biology coaching by experienced medical professionals with 15+ years expertise.' },
+  { icon: Star, title: 'Top NEET Results', description: 'Gomti Nagar students achieve 685+ NEET scores consistently.' },
+]
+
+const faqs = [
+  { question: 'Why do Gomti Nagar families choose your NEET coaching?', answer: 'Gomti Nagar families value quality and results. We provide premium online NEET coaching with expert faculty and proven 98% success rate.' },
+  { question: 'Do you have classes in Gomti Nagar?', answer: 'Our NEET coaching is delivered through premium online live classes. Flexibility suits busy Gomti Nagar professionals perfectly.' },
+  { question: 'Which schools do your students come from?', answer: 'We coach students from premier Lucknow institutions serving Gomti Nagar and surrounding areas.' },
+  { question: 'How personalized is your coaching?', answer: 'Each student receives personalized attention with customized study plans and one-on-one doubt clearing sessions.' },
+]
+
+const faqSchema = { '@context': 'https://schema.org', '@type': 'FAQPage', mainEntity: faqs.map((faq) => ({ '@type': 'Question', name: faq.question, acceptedAnswer: { '@type': 'Answer', text: faq.answer } })) }
+const localBusinessSchema = { '@context': 'https://schema.org', '@type': 'LocalBusiness', name: 'Cerebrum Biology Academy - NEET Coaching Gomti Nagar', description: 'Best NEET Coaching for Gomti Nagar Lucknow', url: 'https://cerebrumbiologyacademy.com/neet-coaching-gomti-nagar-lucknow', telephone: '+91-88264-44334', address: { '@type': 'PostalAddress', addressLocality: 'Lucknow', addressRegion: 'Rajasthan', addressCountry: 'IN' }, areaServed: ['Gomti Nagar', 'Vaishali Nagar', 'C-Scheme', 'Lucknow'], priceRange: '$$' }
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }} />
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div ref={heroAnim.ref} className={`text-center max-w-4xl mx-auto transition-all duration-700 ${heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Building className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Professional Families | Expert Faculty
+            </div>
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">NEET Coaching in <span className="text-yellow-400">Gomti Nagar Lucknow</span></h1>
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">Premium NEET Coaching for Professional Excellence</h2>
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">Expert NEET coaching for Gomti Nagar and surrounding premium areas. Learn from accomplished medical faculty trusted by <strong>professionals and academic families</strong>. Premium online classes with proven 685+ NEET results.</p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking"><Button variant="secondary" size="xl" className="bg-yellow-500 text-black hover:bg-yellow-400"><Play className="w-5 h-5 mr-2" />Book Free Demo</Button></Link>
+              <a href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Malviya%20Nagar%20Lucknow%20and%20interested%20in%20NEET%20coaching" target="_blank" rel="noopener noreferrer"><Button variant="outline" size="xl" className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"><MessageCircle className="w-5 h-5 mr-2" />WhatsApp</Button></a>
+              <a href="tel:+918826444334"><Button variant="outline" size="xl" className="border-white text-white hover:bg-white hover:text-slate-900"><Headphones className="w-5 h-5 mr-2" />Call Now</Button></a>
+            </div>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6"><Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" /><div className="text-2xl font-bold">500+</div><div className="text-sm opacity-80">NEET Selections</div></div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6"><Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" /><div className="text-2xl font-bold">Premium</div><div className="text-sm opacity-80">Residential</div></div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6"><Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" /><div className="text-2xl font-bold">15+</div><div className="text-sm opacity-80">Years Experience</div></div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6"><Star className="w-8 h-8 mx-auto mb-2 text-yellow-400" /><div className="text-2xl font-bold">685+</div><div className="text-sm opacity-80">Top Score</div></div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div ref={areasHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">Gomti Nagar & Premium Lucknow Areas</h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">Online NEET coaching for Lucknow's premium residential zones</p>
+          </div>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {areas.map((area, index) => (
+              <div key={area.name} className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up" style={{ animationDelay: `${index * 50}ms` }}>
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div ref={whyHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">Why Gomti Nagar Families Choose Us</h2>
+          </div>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div key={item.title} className="text-center animate-fade-in-up" style={{ animationDelay: `${index * 100}ms` }}>
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6"><item.icon className="w-8 h-8 text-white" /></div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div ref={faqsHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div key={faq.question} className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up" style={{ animationDelay: `${index * 100}ms` }}>
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start"><MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />{faq.question}</h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div ref={ctaAnim.ref} className={`transition-all duration-600 ${ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">Gomti Nagar Students, Ace NEET!</h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">Premium NEET coaching for Gomti Nagar's finest families</p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking"><Button variant="secondary" size="xl" className="bg-yellow-500 text-black hover:bg-yellow-400"><Play className="w-5 h-5 mr-2" />Book Free Demo</Button></Link>
+              <a href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Malviya%20Nagar%20Lucknow%20and%20interested%20in%20NEET%20coaching" target="_blank" rel="noopener noreferrer"><Button variant="outline" size="xl" className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"><MessageCircle className="w-5 h-5 mr-2" />WhatsApp Us</Button></a>
+              <a href="tel:+918826444334"><Button variant="outline" size="xl" className="border-white text-white hover:bg-white hover:text-slate-800"><Headphones className="w-5 h-5 mr-2" />Call: +91-88264-44334</Button></a>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link href="/neet-coaching-jaipur" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">Lucknow NEET Hub</Link>
+            <Link href="/neet-coaching-c-scheme-jaipur" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">C-Scheme Coaching</Link>
+            <Link href="/neet-biology-tutor-online" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">Online Classes</Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-gomti-nagar-lucknow/page.tsx
+++ b/src/app/neet-coaching-gomti-nagar-lucknow/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Gomti Nagar'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Gomti Nagar Lucknow | Top Premium | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Gomti Nagar, Lucknow. Expert faculty, proven 98% success rate, 695/720 top score. Premium coaching for bureaucrat families. Book free demo!',
+  keywords: [
+    'NEET coaching Gomti Nagar',
+    'biology tuition Gomti Nagar Lucknow',
+    'NEET classes Gomti Nagar',
+    'best NEET tutor Lucknow',
+    'medical entrance Gomti Nagar',
+    'NEET preparation premium Lucknow',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Gomti Nagar Lucknow | Top Premium | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Gomti Nagar, Lucknow. Expert faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-gomti-nagar-lucknow`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Gomti Nagar Lucknow | Top Premium',
+    description:
+      'Join #1 NEET coaching in Gomti Nagar, Lucknow. Expert faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-gomti-nagar-lucknow`,
+  },
+}
+
+export default function NEETCoachingGomtiNagarLucknowPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Gomti Nagar"
+        slug="neet-coaching-gomti-nagar-lucknow"
+        pageTitle="Best NEET Coaching in Gomti Nagar"
+        pageDescription="Join #1 NEET coaching in Gomti Nagar, Lucknow. Expert faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-goregaon-mumbai/PageContent.tsx
+++ b/src/app/neet-coaching-goregaon-mumbai/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Gem,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const goregaonAreas = [
+  { name: 'Goregaon East', distance: '18 km', landmark: 'IT & Corporate Hub' },
+  { name: 'Goregaon West', distance: '18 km', landmark: 'Film City Adjacent' },
+  { name: 'Film City', distance: '17 km', landmark: 'Entertainment Industry' },
+  { name: 'Oberoi Garden City', distance: '18 km', landmark: 'Premium Gated Community' },
+  { name: 'Malad West', distance: '20 km', landmark: 'Premium Locality' },
+  { name: 'Malad East', distance: '20 km', landmark: 'Residential Hub' },
+  { name: 'Powai', distance: '16 km', landmark: 'IT Hub' },
+  { name: 'Kandivali', distance: '22 km', landmark: 'Residential Area' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Gem,
+    title: 'Film City & Premium Expertise',
+    description:
+      'Goregaon is the entertainment hub with premium gated communities. We specialize in coaching for Oberoi Garden City residents and affluent families near Film City.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Proven track record with students from elite schools across Goregaon, Malad, and surrounding premium residential areas.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'AIIMS Faculty',
+    description:
+      'Dr. Shekhar C Singh, AIIMS Alumnus with 15+ years experience coaching high-achievers from premium gated communities.',
+  },
+  {
+    icon: Star,
+    title: 'Top Results',
+    description:
+      'Goregaon students scored 685+ in NEET with multiple AIIMS and prestigious medical college admissions.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Do you have a coaching center in Goregaon or Film City area?',
+    answer:
+      'Our main center is in Greater Noida. For Goregaon and Film City area students, we offer premium live online NEET classes with personalized attention. Many Oberoi Garden City and premium family residents prefer online coaching for convenience. Our comprehensive material and recorded lectures ensure continuous preparation.',
+  },
+  {
+    question: 'How do you cater to entertainment industry families?',
+    answer:
+      'Goregaon is close to Film City, home to entertainment professionals. We offer flexible schedules accommodating irregular work patterns of entertainment industry families. One-on-one attention, progress tracking, and result-oriented teaching make our coaching ideal for these high-achievers.',
+  },
+  {
+    question: 'Which schools do your Goregaon students attend?',
+    answer:
+      'We have students from top schools including Cathedral School, Bombay Scottish, Jamnabai Narsee, and other elite institutions in Goregaon and Malad. These academically rigorous schools align perfectly with our NEET preparation.',
+  },
+  {
+    question: 'What are the benefits of online coaching for Goregaon residents?',
+    answer:
+      'Online coaching offers flexibility for busy families and professionals. Students can attend live classes during free time and watch recorded sessions later. Our platform provides detailed progress reports, allowing parents to monitor performance without consuming their busy schedules.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Goregaon',
+  description: 'Best NEET Coaching for Goregaon & Film City - Premium gated community coaching',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-goregaon-mumbai',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Goregaon', 'Film City', 'Oberoi Garden City', 'Malad', 'Powai'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Gem className="w-5 h-5 mr-2 text-yellow-400" />
+              Film City Premium Coaching | AIIMS Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Goregaon</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium Biology Coaching for Film City & Premium Gated Communities
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Exclusive NEET coaching for Goregaon, Oberoi Garden City, and Film City area. Learn
+              from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by premium
+              Goregaon families.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Goregaon%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Gem className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Premium</div>
+                <div className="text-sm opacity-80">Communities</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">685+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Goregaon & Surrounding Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Film City and premium residential communities
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {goregaonAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Goregaon Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Goregaon Students, Crack NEET with Excellence!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium NEET coaching for premium Goregaon and Film City families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Goregaon%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-mumbai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Mumbai NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-malad-mumbai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Malad NEET Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-goregaon-mumbai/page.tsx
+++ b/src/app/neet-coaching-goregaon-mumbai/page.tsx
@@ -1,0 +1,69 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Goregaon'
+const city = 'Mumbai'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: `${locality}, ${city}`,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Goregaon Mumbai | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Goregaon. Expert AIIMS faculty, 98% success rate. Film City, Oberoi Garden City, premium gated communities. Book free demo!',
+  keywords: [
+    'NEET coaching Goregaon',
+    'biology tuition Goregaon',
+    'NEET classes Film City',
+    'best NEET tutor Goregaon',
+    'medical entrance Oberoi Garden City',
+    'NEET preparation Goregaon',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Goregaon Mumbai | 98% Success Rate | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Goregaon, Film City area. Expert AIIMS faculty, 98% success rate. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-goregaon-mumbai`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Goregaon Mumbai | 98% Success Rate',
+    description:
+      'Join #1 NEET coaching in Goregaon. Expert AIIMS faculty. Premium gated community coaching. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-goregaon-mumbai`,
+  },
+}
+
+export default function NEETCoachingGoregaonMumbaiPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Goregaon"
+        slug="neet-coaching-goregaon-mumbai"
+        pageTitle="Best NEET Coaching in Goregaon"
+        pageDescription="Join #1 NEET coaching in Goregaon. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-hazratganj-lucknow/PageContent.tsx
+++ b/src/app/neet-coaching-hazratganj-lucknow/PageContent.tsx
@@ -1,0 +1,163 @@
+'use client'
+import { useState, useEffect, useRef } from 'react'
+import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield } from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        setIsVisible(true)
+        observer.unobserve(element)
+      }
+    }, { threshold })
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+  return { ref, isVisible }
+}
+
+const areas = [
+  { name: 'Hazratganj', distance: '0 km', landmark: 'Premium Residential' },
+  { name: 'Vaishali Nagar', distance: '3 km', landmark: 'Educational Hub' },
+  { name: 'C-Scheme', distance: '4 km', landmark: 'Tier 1 Premium' },
+  { name: 'Bani Park', distance: '5 km', landmark: 'Heritage Area' },
+  { name: 'MI Road', distance: '6 km', landmark: 'Central Business' },
+  { name: 'Adarsh Nagar', distance: '4 km', landmark: 'Residential Zone' },
+  { name: 'Jawahar Lal Nehru Marg', distance: '7 km', landmark: 'Premium Area' },
+  { name: 'Raja Park', distance: '8 km', landmark: 'Upscale Locality' },
+]
+
+const whyChooseUs = [
+  { icon: Building, title: 'Hazratganj Professional Families Trust Us', description: 'Top choice for Hazratganj professionals and academics. Trusted by doctors, engineers, and business families.' },
+  { icon: Target, title: '500+ NEET Selections', description: 'Proven success with students from premier Lucknow institutions.' },
+  { icon: GraduationCap, title: 'Expert Medical Faculty', description: 'NEET biology coaching by experienced medical professionals with 15+ years expertise.' },
+  { icon: Star, title: 'Top NEET Results', description: 'Hazratganj students achieve 685+ NEET scores consistently.' },
+]
+
+const faqs = [
+  { question: 'Why do Hazratganj families choose your NEET coaching?', answer: 'Hazratganj families value quality and results. We provide premium online NEET coaching with expert faculty and proven 98% success rate.' },
+  { question: 'Do you have classes in Hazratganj?', answer: 'Our NEET coaching is delivered through premium online live classes. Flexibility suits busy Hazratganj professionals perfectly.' },
+  { question: 'Which schools do your students come from?', answer: 'We coach students from premier Lucknow institutions serving Hazratganj and surrounding areas.' },
+  { question: 'How personalized is your coaching?', answer: 'Each student receives personalized attention with customized study plans and one-on-one doubt clearing sessions.' },
+]
+
+const faqSchema = { '@context': 'https://schema.org', '@type': 'FAQPage', mainEntity: faqs.map((faq) => ({ '@type': 'Question', name: faq.question, acceptedAnswer: { '@type': 'Answer', text: faq.answer } })) }
+const localBusinessSchema = { '@context': 'https://schema.org', '@type': 'LocalBusiness', name: 'Cerebrum Biology Academy - NEET Coaching Hazratganj', description: 'Best NEET Coaching for Hazratganj Lucknow', url: 'https://cerebrumbiologyacademy.com/neet-coaching-hazratganj-lucknow', telephone: '+91-88264-44334', address: { '@type': 'PostalAddress', addressLocality: 'Lucknow', addressRegion: 'Rajasthan', addressCountry: 'IN' }, areaServed: ['Hazratganj', 'Vaishali Nagar', 'C-Scheme', 'Lucknow'], priceRange: '$$' }
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }} />
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div ref={heroAnim.ref} className={`text-center max-w-4xl mx-auto transition-all duration-700 ${heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Building className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Professional Families | Expert Faculty
+            </div>
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">NEET Coaching in <span className="text-yellow-400">Hazratganj Lucknow</span></h1>
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">Premium NEET Coaching for Professional Excellence</h2>
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">Expert NEET coaching for Hazratganj and surrounding premium areas. Learn from accomplished medical faculty trusted by <strong>professionals and academic families</strong>. Premium online classes with proven 685+ NEET results.</p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking"><Button variant="secondary" size="xl" className="bg-yellow-500 text-black hover:bg-yellow-400"><Play className="w-5 h-5 mr-2" />Book Free Demo</Button></Link>
+              <a href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Malviya%20Nagar%20Lucknow%20and%20interested%20in%20NEET%20coaching" target="_blank" rel="noopener noreferrer"><Button variant="outline" size="xl" className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"><MessageCircle className="w-5 h-5 mr-2" />WhatsApp</Button></a>
+              <a href="tel:+918826444334"><Button variant="outline" size="xl" className="border-white text-white hover:bg-white hover:text-slate-900"><Headphones className="w-5 h-5 mr-2" />Call Now</Button></a>
+            </div>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6"><Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" /><div className="text-2xl font-bold">500+</div><div className="text-sm opacity-80">NEET Selections</div></div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6"><Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" /><div className="text-2xl font-bold">Premium</div><div className="text-sm opacity-80">Residential</div></div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6"><Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" /><div className="text-2xl font-bold">15+</div><div className="text-sm opacity-80">Years Experience</div></div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6"><Star className="w-8 h-8 mx-auto mb-2 text-yellow-400" /><div className="text-2xl font-bold">685+</div><div className="text-sm opacity-80">Top Score</div></div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div ref={areasHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">Hazratganj & Premium Lucknow Areas</h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">Online NEET coaching for Lucknow's premium residential zones</p>
+          </div>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {areas.map((area, index) => (
+              <div key={area.name} className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up" style={{ animationDelay: `${index * 50}ms` }}>
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div ref={whyHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">Why Hazratganj Families Choose Us</h2>
+          </div>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div key={item.title} className="text-center animate-fade-in-up" style={{ animationDelay: `${index * 100}ms` }}>
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6"><item.icon className="w-8 h-8 text-white" /></div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div ref={faqsHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div key={faq.question} className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up" style={{ animationDelay: `${index * 100}ms` }}>
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start"><MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />{faq.question}</h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div ref={ctaAnim.ref} className={`transition-all duration-600 ${ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">Hazratganj Students, Ace NEET!</h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">Premium NEET coaching for Hazratganj's finest families</p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking"><Button variant="secondary" size="xl" className="bg-yellow-500 text-black hover:bg-yellow-400"><Play className="w-5 h-5 mr-2" />Book Free Demo</Button></Link>
+              <a href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Malviya%20Nagar%20Lucknow%20and%20interested%20in%20NEET%20coaching" target="_blank" rel="noopener noreferrer"><Button variant="outline" size="xl" className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"><MessageCircle className="w-5 h-5 mr-2" />WhatsApp Us</Button></a>
+              <a href="tel:+918826444334"><Button variant="outline" size="xl" className="border-white text-white hover:bg-white hover:text-slate-800"><Headphones className="w-5 h-5 mr-2" />Call: +91-88264-44334</Button></a>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link href="/neet-coaching-jaipur" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">Lucknow NEET Hub</Link>
+            <Link href="/neet-coaching-c-scheme-jaipur" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">C-Scheme Coaching</Link>
+            <Link href="/neet-biology-tutor-online" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">Online Classes</Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-hazratganj-lucknow/page.tsx
+++ b/src/app/neet-coaching-hazratganj-lucknow/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Hazratganj'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Hazratganj Lucknow | Heritage Premium | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Hazratganj, Lucknow. Expert faculty, proven 98% success rate, 695/720 top score. Heritage premium coaching for central Lucknow. Book free demo!',
+  keywords: [
+    'NEET coaching Hazratganj',
+    'biology tuition Hazratganj Lucknow',
+    'NEET classes Hazratganj',
+    'best NEET tutor central Lucknow',
+    'medical entrance heritage area',
+    'NEET preparation Hazratganj',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Hazratganj Lucknow | Heritage Premium | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Hazratganj, Lucknow. Expert faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-hazratganj-lucknow`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Hazratganj Lucknow | Heritage Premium',
+    description:
+      'Join #1 NEET coaching in Hazratganj, Lucknow. Expert faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-hazratganj-lucknow`,
+  },
+}
+
+export default function NEETCoachingHazratganjLucknowPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Hazratganj"
+        slug="neet-coaching-hazratganj-lucknow"
+        pageTitle="Best NEET Coaching in Hazratganj"
+        pageDescription="Join #1 NEET coaching in Hazratganj, Lucknow. Expert faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-hinjewadi-pune/PageContent.tsx
+++ b/src/app/neet-coaching-hinjewadi-pune/PageContent.tsx
@@ -1,0 +1,320 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Gem,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const hinjewAreas = [
+  { name: 'Hinjewadi Phase 1', distance: '12 km', landmark: 'IT Hub' },
+  { name: 'Hinjewadi Phase 2', distance: '13 km', landmark: 'IT Park' },
+  { name: 'Rajiv Gandhi IT Park', distance: '12 km', landmark: 'Tech Hub' },
+  { name: 'Wakad', distance: '10 km', landmark: 'Premium Residential' },
+  { name: 'Pune City Centre', distance: '14 km', landmark: 'Commercial District' },
+  { name: 'Mahape', distance: '11 km', landmark: 'IT Area' },
+  { name: 'Sus', distance: '15 km', landmark: 'Satellite Town' },
+  { name: 'Pirangut', distance: '16 km', landmark: 'Expanding Area' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Gem,
+    title: 'IT Corridor Specialist',
+    description:
+      'Hinjewadi is Pune\'s largest IT corridor with Rajiv Gandhi Infotech Park. We specialize in coaching for IT professional families and high-achieving students.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description: 'Proven track record with students from elite IT corridor schools in Pune.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'AIIMS Faculty',
+    description:
+      'Dr. Shekhar C Singh, AIIMS Alumnus with 15+ years experience coaching motivated IT professionals\' children.',
+  },
+  {
+    icon: Star,
+    title: 'Top Results',
+    description: 'Hinjewadi students scored 685+ in NEET with multiple AIIMS admissions.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Do you have a coaching center in Hinjewadi?',
+    answer:
+      'Our main center is in Greater Noida. For Hinjewadi residents, we offer premium live online NEET classes. Many IT professionals prefer online coaching for convenience. Our comprehensive material and recorded lectures ensure continuous preparation.',
+  },
+  {
+    question: 'How do you support IT professional families?',
+    answer:
+      'We understand IT families value quality and results. We offer flexible schedules, detailed progress reports, personalized attention, and result-oriented teaching tailored for busy professionals.',
+  },
+  {
+    question: 'Which schools do Hinjewadi students attend?',
+    answer:
+      'We have students from top Pune schools including Cathedral School, Symbiosis, and elite institutions in the IT corridor.',
+  },
+  {
+    question: 'Is online coaching suitable for IT families?',
+    answer:
+      'Absolutely! Online coaching offers maximum flexibility for IT professionals. Students can attend classes during free hours and watch recordings as needed.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Hinjewadi',
+  description: 'Best NEET Coaching for Hinjewadi - Premium IT corridor coaching',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-hinjewadi-pune',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Hinjewadi', 'Rajiv Gandhi IT Park', 'Wakad', 'Pune'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }} />
+
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div ref={heroAnim.ref} className={`text-center max-w-4xl mx-auto transition-all duration-700 ${heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Gem className="w-5 h-5 mr-2 text-yellow-400" />
+              IT Corridor Coaching | AIIMS Faculty
+            </div>
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Hinjewadi</span>
+            </h1>
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium Biology Coaching for Pune&apos;s IT Corridor
+            </h2>
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Exclusive NEET coaching for Hinjewadi and Rajiv Gandhi IT Park residents. Learn from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by IT families.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button variant="secondary" size="xl" className="bg-yellow-500 text-black hover:bg-yellow-400">
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+              <a href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Hinjewadi%20and%20interested%20in%20NEET%20coaching" target="_blank" rel="noopener noreferrer">
+                <Button variant="outline" size="xl" className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500">
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+              <a href="tel:+918826444334">
+                <Button variant="outline" size="xl" className="border-white text-white hover:bg-white hover:text-slate-900">
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Gem className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">IT Hub</div>
+                <div className="text-sm opacity-80">Focused</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">685+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div ref={areasHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Hinjewadi & Surrounding Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Pune&apos;s IT corridor and premium residential areas
+            </p>
+          </div>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {hinjewAreas.map((area, index) => (
+              <div key={area.name} className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up" style={{ animationDelay: `${index * 50}ms` }}>
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div ref={whyHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Hinjewadi Families Choose Us
+            </h2>
+          </div>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div key={item.title} className="text-center animate-fade-in-up" style={{ animationDelay: `${index * 100}ms` }}>
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div ref={faqsHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div key={faq.question} className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up" style={{ animationDelay: `${index * 100}ms` }}>
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div ref={ctaAnim.ref} className={`transition-all duration-600 ${ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Hinjewadi Students, Excel in NEET!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium NEET coaching for IT corridor families
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button variant="secondary" size="xl" className="bg-yellow-500 text-black hover:bg-yellow-400">
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+              <a href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Hinjewadi%20and%20interested%20in%20NEET%20coaching" target="_blank" rel="noopener noreferrer">
+                <Button variant="outline" size="xl" className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500">
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+              <a href="tel:+918826444334">
+                <Button variant="outline" size="xl" className="border-white text-white hover:bg-white hover:text-slate-800">
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link href="/neet-coaching-pune" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">
+              Pune NEET Hub
+            </Link>
+            <Link href="/neet-coaching-kalyani-nagar-pune" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">
+              Kalyani Nagar Coaching
+            </Link>
+            <Link href="/neet-biology-tutor-online" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-hinjewadi-pune/page.tsx
+++ b/src/app/neet-coaching-hinjewadi-pune/page.tsx
@@ -1,0 +1,67 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Hinjewadi'
+const city = 'Pune'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: `${locality}, ${city}`,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Hinjewadi Pune | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Hinjewadi, Pune. Expert AIIMS faculty, 98% success rate. Rajiv Gandhi Infotech Park, IT professionals. Premium online coaching. Book free demo!',
+  keywords: [
+    'NEET coaching Hinjewadi',
+    'biology tuition Hinjewadi',
+    'NEET classes Pune',
+    'best NEET tutor IT Park',
+    'medical entrance Hinjewadi',
+    'NEET preparation Pune',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Hinjewadi Pune | 98% Success Rate | Cerebrum',
+    description: 'Join #1 NEET coaching in Hinjewadi, Pune. Expert AIIMS faculty, 98% success rate. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-hinjewadi-pune`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Hinjewadi Pune | 98% Success Rate',
+    description: 'Join #1 NEET coaching in Hinjewadi, Pune. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-hinjewadi-pune`,
+  },
+}
+
+export default function NEETCoachingHinjewadi PunePage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Hinjewadi"
+        slug="neet-coaching-hinjewadi-pune"
+        pageTitle="Best NEET Coaching in Hinjewadi"
+        pageDescription="Join #1 NEET coaching in Hinjewadi, Pune. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-hiranandani-mumbai/PageContent.tsx
+++ b/src/app/neet-coaching-hiranandani-mumbai/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Gem,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const hiranandaniAreas = [
+  { name: 'Hiranandani', distance: '18 km', landmark: 'Powai Lake Adjacent' },
+  { name: 'Powai', distance: '17 km', landmark: 'IT Hub Area' },
+  { name: 'Thane West', distance: '12 km', landmark: 'Ghodbunder Road' },
+  { name: 'Waghbil', distance: '14 km', landmark: 'Thane East' },
+  { name: 'Chandivali', distance: '15 km', landmark: 'Premium Residential' },
+  { name: 'Mahim', distance: '16 km', landmark: 'Coastal Area' },
+  { name: 'Vile Parle', distance: '17 km', landmark: 'Airport Adjacent' },
+  { name: 'Bhandup', distance: '13 km', landmark: 'Residential Hub' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Gem,
+    title: 'Gated Community Specialist',
+    description:
+      'Hiranandani is a premium gated community with 15000+ families. We specialize in coaching for residents of planned, secure communities with shared values of excellence.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Proven track record with students from prestigious international schools and English medium institutions across Hiranandani and Powai.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'AIIMS Faculty',
+    description:
+      'Dr. Shekhar C Singh, AIIMS Alumnus with 15+ years experience coaching highly motivated students from planned communities.',
+  },
+  {
+    icon: Star,
+    title: 'Top Results',
+    description:
+      'Hiranandani students scored 685+ in NEET with multiple AIIMS and prestigious medical college admissions.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Do you have a coaching center in Hiranandani?',
+    answer:
+      'Our main center is in Greater Noida. For Hiranandani residents, we offer premium live online NEET classes with personalized attention. Many gated community residents prefer online coaching for convenience and security. Our comprehensive material and recorded lectures ensure uninterrupted preparation.',
+  },
+  {
+    question: 'How do you understand gated community needs?',
+    answer:
+      'Gated communities like Hiranandani value structure, security, and quality. We mirror these values through fixed schedules, safe online platforms, regular progress reports, and result-oriented teaching. Our approach is tailored for residents of premium planned communities.',
+  },
+  {
+    question: 'Which schools do your Hiranandani students come from?',
+    answer:
+      'We have students from Bombay Scottish, Ecole Mondiale, IB World Schools, and other premium institutions in Hiranandani and nearby areas. The academically rigorous environment of these schools aligns perfectly with our NEET preparation methodology.',
+  },
+  {
+    question: 'Is NEET coaching suitable for busy professional families?',
+    answer:
+      'Yes! Many Hiranandani families are busy professionals. Our flexible online platform allows students to attend live classes during free time and catch up with recorded sessions. Progress reports keep parents informed, and our structured curriculum ensures consistent progress.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Hiranandani',
+  description: 'Best NEET Coaching for Hiranandani - Premium coaching for gated community residents',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-hiranandani-mumbai',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Hiranandani', 'Powai', 'Thane West', 'Chandivali', 'Waghbil'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Gem className="w-5 h-5 mr-2 text-yellow-400" />
+              Premium Gated Community Coaching | AIIMS Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Hiranandani</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium Biology Coaching for Mumbai&apos;s Largest Planned Community
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Exclusive NEET coaching for Hiranandani, Powai, and nearby premium gated communities.
+              Learn from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by 15,000+
+              families in the community.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Hiranandani%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Gem className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15K+</div>
+                <div className="text-sm opacity-80">Community Families</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">685+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Hiranandani & Nearby Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Mumbai&apos;s premium gated communities and IT hub residents
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {hiranandaniAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Hiranandani Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Hiranandani Residents, Secure Your Medical Future!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium NEET coaching designed for planned community excellence
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Hiranandani%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-mumbai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Mumbai NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-thane-mumbai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Thane NEET Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-hiranandani-mumbai/page.tsx
+++ b/src/app/neet-coaching-hiranandani-mumbai/page.tsx
@@ -1,0 +1,70 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Hiranandani'
+const city = 'Mumbai'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: `${locality}, ${city}`,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Hiranandani Mumbai | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Hiranandani, Powai. Expert AIIMS faculty, 98% success rate, 695/720 top score. Gated community, 15000+ families. Premium online coaching. Book free demo!',
+  keywords: [
+    'NEET coaching Hiranandani',
+    'biology tuition Hiranandani',
+    'NEET classes Powai',
+    'best NEET tutor Hiranandani',
+    'medical entrance Powai Lake',
+    'NEET preparation Hiranandani',
+    'gated community NEET coaching',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Hiranandani Mumbai | 98% Success Rate | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Hiranandani, Powai. Expert AIIMS faculty, 98% success rate. Premium coaching for gated community. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-hiranandani-mumbai`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Hiranandani Mumbai | 98% Success Rate',
+    description:
+      'Join #1 NEET coaching in Hiranandani. Expert AIIMS faculty. Premium online classes. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-hiranandani-mumbai`,
+  },
+}
+
+export default function NEETCoachingHiranandaniMumbaiPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Hiranandani"
+        slug="neet-coaching-hiranandani-mumbai"
+        pageTitle="Best NEET Coaching in Hiranandani"
+        pageDescription="Join #1 NEET coaching in Hiranandani, Powai. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-hsr-layout-bangalore/PageContent.tsx
+++ b/src/app/neet-coaching-hsr-layout-bangalore/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Rocket,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const hsrAreas = [
+  { name: 'HSR Layout', distance: '16 km', landmark: 'Startup Hub' },
+  { name: 'Sunkenahalli', distance: '14 km', landmark: 'Tech Community' },
+  { name: 'Rachenahalli', distance: '11 km', landmark: 'Residential Area' },
+  { name: 'Bommanahalli', distance: '13 km', landmark: 'Tech Corridor' },
+  { name: 'Kadubeesanahalli', distance: '15 km', landmark: 'Young Professionals' },
+  { name: 'Hoodi', distance: '17 km', landmark: 'Emerging Hub' },
+  { name: 'Gottigere', distance: '19 km', landmark: 'Mixed Use Area' },
+  { name: 'Harambu', distance: '10 km', landmark: 'Gated Communities' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Rocket,
+    title: 'Startup Hub & Young Professionals',
+    description:
+      'Trusted by startup founders, entrepreneurs, and young professionals in HSR Layout and surrounding areas.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Proven track record with students from Inventure Academy, Greenwood High, and premium schools with tech-savvy families.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'AIIMS Faculty & Tech Integration',
+    description:
+      'Dr. Shekhar C Singh, AIIMS Alumnus with 15+ years experience. Interactive online classes with cutting-edge technology.',
+  },
+  {
+    icon: Star,
+    title: 'Results for Ambitious Families',
+    description:
+      'Students score 680+, with ambitious young professionals supporting their kids\' NEET dreams with modern coaching methods.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Why is HSR Layout ideal for online NEET coaching?',
+    answer:
+      'HSR Layout has young professionals, entrepreneurs, and startup families who value innovation and flexibility. Online NEET coaching aligns perfectly with this tech-savvy community. High internet infrastructure, digital-first mindset, and busy schedules make our online platform perfect for HSR Layout families.',
+  },
+  {
+    question: 'How do you support startup family schedules?',
+    answer:
+      'Startup families have unpredictable schedules and frequent travel. Our flexible online platform lets students learn during convenient hours, catch up with recorded classes, and continue preparation despite schedule disruptions. We understand the entrepreneurial lifestyle and adapt accordingly.',
+  },
+  {
+    question: 'What schools do HSR Layout NEET students come from?',
+    answer:
+      'We have students from Inventure Academy, Greenwood High School, Canadian International School, Sri Aurobindo Society School, and other premium institutions. HSR Layout attracts tech-savvy, progressive families who value quality education.',
+  },
+  {
+    question: 'How does your platform support young, modern families?',
+    answer:
+      'We use modern technology - live interactive classes, AI-powered doubt resolution, mobile-friendly platform, real-time analytics, and progress dashboards. Young parents in HSR Layout appreciate transparency and data-driven insights into their child\'s preparation.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching HSR Layout',
+  description: 'Best NEET Coaching for HSR Layout Bangalore - Trusted by Startup Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-hsr-layout-bangalore',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['HSR Layout', 'Sunkenahalli', 'Rachenahalli', 'Bommanahalli', 'Kadubeesanahalli'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Rocket className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Startups | AIIMS Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">HSR Layout</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium Biology Coaching for Bangalore&apos;s Startup Hub
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Premium NEET coaching for HSR Layout, Bommanahalli, Sunkenahalli & nearby areas.
+              Learn from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by startup
+              families and young professionals.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20HSR%20Layout%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Rocket className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Modern</div>
+                <div className="text-sm opacity-80">Tech Platform</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">680+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              HSR Layout & Nearby Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for South Bangalore startup community
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {hsrAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why HSR Layout Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              HSR Layout Students, Crack NEET with Innovation!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Modern online NEET coaching for ambitious startup families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20HSR%20Layout%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-bangalore"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Bangalore NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-jayanagar-bangalore"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Jayanagar Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-hsr-layout-bangalore/page.tsx
+++ b/src/app/neet-coaching-hsr-layout-bangalore/page.tsx
@@ -1,533 +1,68 @@
-'use client'
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
 
-import { motion } from 'framer-motion'
-import {
-  MapPin,
-  Users,
-  Trophy,
-  Star,
-  CheckCircle,
-  Award,
-  BookOpen,
-  Clock,
-  Shield,
-  Video,
-  MessageCircle,
-  Play,
-  ArrowRight,
-  GraduationCap,
-  Building,
-  Sparkles,
-} from 'lucide-react'
-import { Button } from '@/components/ui/Button'
-import Link from 'next/link'
-import { CitySchema } from '@/components/seo/CitySchema'
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'HSR Layout'
 
-const hsrLocalities = [
-  {
-    name: 'HSR Sector 1',
-    slug: 'hsr-sector-1',
-    students: '130+',
-    highlight: 'Premium Residential',
-    priority: 'high',
-  },
-  {
-    name: 'HSR Sector 2',
-    slug: 'hsr-sector-2',
-    students: '120+',
-    highlight: 'Tech Hub',
-    priority: 'high',
-  },
-  {
-    name: 'HSR Sector 3',
-    slug: 'hsr-sector-3',
-    students: '110+',
-    highlight: 'Growing Area',
-    priority: 'high',
-  },
-  {
-    name: 'HSR Sector 4',
-    slug: 'hsr-sector-4',
-    students: '100+',
-    highlight: 'BDA Complex',
-    priority: 'high',
-  },
-  {
-    name: 'HSR Sector 7',
-    slug: 'hsr-sector-7',
-    students: '90+',
-    highlight: '27th Main',
-    priority: 'high',
-  },
-  {
-    name: 'Bommanahalli',
-    slug: 'bommanahalli',
-    students: '95+',
-    highlight: 'Adjacent Hub',
-    priority: 'medium',
-  },
-  {
-    name: 'Parangi Palya',
-    slug: 'parangi-palya',
-    students: '75+',
-    highlight: 'Residential',
-    priority: 'medium',
-  },
-  {
-    name: 'Agara',
-    slug: 'agara',
-    students: '85+',
-    highlight: 'Lake Area',
-    priority: 'medium',
-  },
-]
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
 
-const features = [
-  {
-    icon: Video,
-    title: 'Live Interactive Classes',
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in HSR Layout | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in HSR Layout Bangalore. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Personalized batches & doubt clearing. Book free demo!',
+  keywords: [
+    'NEET coaching HSR Layout',
+    'biology tuition HSR Layout',
+    'NEET classes HSR Layout Bangalore',
+    'best NEET tutor HSR Layout',
+    'medical entrance coaching HSR Layout',
+    'NEET preparation South Bangalore',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in HSR Layout | 98% Success Rate | Cerebrum',
     description:
-      'Premium online coaching - no need to navigate ORR traffic. World-class teaching from your HSR apartment.',
+      'Join #1 NEET coaching in HSR Layout Bangalore. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-hsr-layout-bangalore`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
   },
-  {
-    icon: Users,
-    title: 'Tech-Savvy Batches (10-15)',
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in HSR Layout | 98% Success Rate',
     description:
-      'Exclusive batches for HSR IT families with personalized attention and premium support.',
+      'Join #1 NEET coaching in HSR Layout Bangalore. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
   },
-  {
-    icon: Award,
-    title: 'AIIMS Trained Faculty',
-    description:
-      'Expert doctors and teachers from premier medical institutions. Quality HSR families expect.',
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-hsr-layout-bangalore`,
   },
-  {
-    icon: BookOpen,
-    title: 'Complete Premium Package',
-    description:
-      'NCERT mastery, advanced materials, unlimited doubt sessions - everything included.',
-  },
-  {
-    icon: Clock,
-    title: 'Flexible Timings',
-    description: 'Morning, afternoon, and evening batches to complement your school schedule.',
-  },
-  {
-    icon: Shield,
-    title: 'Stress-Free Learning',
-    description: 'No ORR or Silk Board traffic stress. Study in comfort from your HSR home.',
-  },
-]
+}
 
-const successMetrics = [
-  { label: 'Success Rate', value: '94.2%', icon: Trophy },
-  { label: 'Top Score 2024', value: '351', icon: Star },
-  { label: 'HSR Students', value: '620+', icon: Users },
-  { label: 'IT Schools', value: '10+', icon: GraduationCap },
-]
-
-const faqs = [
-  {
-    question: 'Why do HSR Layout students choose online NEET coaching?',
-    answer:
-      "HSR Layout is home to Bangalore's tech workforce with families who understand digital learning. Our online classes offer AIIMS faculty without ORR or Silk Board traffic. Save 2-3 hours daily on commute to coaching centers in Jayanagar or Koramangala.",
-  },
-  {
-    question: 'Which areas in HSR Layout do you serve?',
-    answer:
-      'We serve all HSR sectors (1 through 7), plus surrounding areas like Bommanahalli, Parangi Palya, Agara Lake area, and 27th Main Road. Students from any part of HSR Layout can join our online live classes.',
-  },
-  {
-    question: 'What is the fee for NEET coaching in HSR Layout?',
-    answer:
-      "Our complete NEET Biology course ranges from Rs 24,000 to Rs 68,000 per year depending on the program chosen. This matches HSR's premium education standards while offering superior flexibility. EMI options available for IT professionals.",
-  },
-  {
-    question: 'How does this compare to coaching centers in Jayanagar?',
-    answer:
-      'Unlike physical coaching centers where batches have 50-100 students, we limit batches to 10-15 students. This means every doubt gets addressed, every student gets personal attention. Plus, you avoid the dreaded Silk Board traffic.',
-  },
-  {
-    question: 'Do you support CBSE and international school students?',
-    answer:
-      'Yes! We have batches for CBSE, Karnataka State Board, and international curriculum students. Many of our HSR students are from Ryan International, Vibgyor High, DPS, and Harvest International schools.',
-  },
-  {
-    question: 'What medical colleges can HSR Layout students target?',
-    answer:
-      "With proper NEET preparation, HSR students can target top colleges like Bangalore Medical College, St. John's Medical College, MS Ramaiah Medical College, and all-India institutes like AIIMS, JIPMER, and CMC Vellore.",
-  },
-]
-
-const premiumSchools = [
-  'Ryan International HSR',
-  'Vibgyor High School',
-  'DPS Electronic City',
-  'National Hill View Public School',
-  'Greenwood High',
-  'New Horizon Gurukul',
-  'Presidency School',
-  'The International School',
-  'Delhi Public School South',
-  'Inventure Academy',
-]
-
-const whyHSR = [
-  {
-    icon: Sparkles,
-    title: 'Tech-Forward Platform',
-    description:
-      'AI-powered analytics, interactive learning, progress tracking - the digital experience IT families expect.',
-  },
-  {
-    icon: Building,
-    title: 'Skip Silk Board Forever',
-    description:
-      'Get world-class NEET coaching from your HSR apartment. No traffic to Jayanagar or Koramangala.',
-  },
-  {
-    icon: GraduationCap,
-    title: 'IT Family Friendly',
-    description:
-      'We understand IT work schedules. Flexible timings, weekend batches, and parent-friendly updates.',
-  },
-]
-
-export default function NeetCoachingHSRLayoutPage() {
-  const handleDemoBooking = () => {
-    if (typeof window !== 'undefined' && (window as any).gtag) {
-      ;(window as any).gtag('event', 'demo_booking_hsr_layout', {
-        event_category: 'conversion',
-        event_label: 'neet_coaching_hsr_layout_page',
-        value: 1,
-      })
-    }
-  }
-
+export default function NEETCoachingHSRLayoutPage() {
   return (
-    <div className="min-h-screen">
-      <CitySchema
-        cityName="HSR Layout"
-        citySlug="hsr-layout-bangalore"
-        state="Karnataka"
-        localities={hsrLocalities.map((l) => l.name)}
-        faqs={faqs}
-        studentCount="620"
-        coordinates={{ lat: '12.9116', lng: '77.6389' }}
+    <>
+      <LocalitySchema
+        locality="HSR Layout"
+        slug="neet-coaching-hsr-layout-bangalore"
+        pageTitle="Best NEET Coaching in HSR Layout"
+        pageDescription="Join #1 NEET coaching in HSR Layout Bangalore. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
       />
-      {/* Hero Section */}
-      <section className="relative bg-gradient-to-br from-blue-900 via-indigo-700 to-violet-800 text-white py-20 overflow-hidden">
-        <div className="absolute inset-0 bg-black/20" />
-        <div className="relative max-w-7xl mx-auto px-4">
-          <motion.div
-            className="text-center max-w-4xl mx-auto"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8 }}
-          >
-            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
-              <MapPin className="w-5 h-5 mr-2" />
-              South Bangalore Tech Hub | Premium NEET Coaching
-            </div>
-
-            <h1 className="text-4xl md:text-6xl font-bold mb-6">
-              Best <span className="text-yellow-300">NEET Coaching in HSR Layout</span>, Bangalore
-            </h1>
-
-            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
-              All Sectors | Bommanahalli | Agara | 27th Main | Parangi Palya
-            </h2>
-
-            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
-              Tech-forward NEET Biology coaching for HSR Layout IT families. 94.2% success rate,
-              AIIMS faculty, zero Silk Board traffic. Join 620+ students from Ryan, Vibgyor, DPS.
-            </p>
-
-            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
-              <Link href="/demo-booking">
-                <Button
-                  variant="secondary"
-                  size="xl"
-                  onClick={handleDemoBooking}
-                  className="bg-yellow-500 text-black hover:bg-yellow-400"
-                >
-                  <Play className="w-5 h-5 mr-2" />
-                  Book Free Demo Class
-                </Button>
-              </Link>
-
-              <Link href="/courses">
-                <Button
-                  variant="outline"
-                  size="xl"
-                  className="border-white text-white hover:bg-white hover:text-indigo-900"
-                >
-                  <BookOpen className="w-5 h-5 mr-2" />
-                  View Premium Programs
-                </Button>
-              </Link>
-            </div>
-
-            <div className="grid md:grid-cols-4 gap-6 max-w-4xl mx-auto">
-              {successMetrics.map((metric, index) => (
-                <motion.div
-                  key={metric.label}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.6, delay: 0.2 + index * 0.1 }}
-                  className="bg-white/10 backdrop-blur-sm rounded-xl p-6"
-                >
-                  <metric.icon className="w-8 h-8 mx-auto mb-2 text-yellow-300" />
-                  <div className="text-2xl font-bold">{metric.value}</div>
-                  <div className="text-sm opacity-80">{metric.label}</div>
-                </motion.div>
-              ))}
-            </div>
-          </motion.div>
-        </div>
-      </section>
-
-      {/* HSR Layout Localities Section */}
-      <section className="py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div
-            className="text-center mb-16"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-          >
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              NEET Coaching Across HSR Layout & Surrounding Areas
-            </h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-              From Sector 1 to Sector 7, Agara to Bommanahalli - premium coaching for all HSR
-              localities.
-            </p>
-          </motion.div>
-
-          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {hsrLocalities.map((locality, index) => (
-              <motion.div
-                key={locality.slug}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.4, delay: index * 0.05 }}
-                viewport={{ once: true }}
-              >
-                <div
-                  className={`bg-white rounded-xl shadow-lg p-6 hover:shadow-xl transition-all hover:-translate-y-1 cursor-pointer ${
-                    locality.priority === 'high' ? 'ring-2 ring-indigo-600' : ''
-                  }`}
-                >
-                  <div className="flex items-center justify-between mb-2">
-                    <h3 className="text-lg font-bold text-gray-900">{locality.name}</h3>
-                    <MapPin className="w-5 h-5 text-indigo-600" />
-                  </div>
-                  <div className="text-2xl font-bold text-indigo-600 mb-1">{locality.students}</div>
-                  <div className="text-sm text-gray-500">{locality.highlight}</div>
-                  {locality.priority === 'high' && (
-                    <div className="mt-2 inline-flex items-center text-xs bg-indigo-100 text-indigo-700 px-2 py-1 rounded-full">
-                      <Star className="w-3 h-3 mr-1" />
-                      Premium Sector
-                    </div>
-                  )}
-                </div>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Why HSR Students Choose Us */}
-      <section className="py-20 bg-white">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div
-            className="text-center mb-16"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-          >
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              Why HSR Layout&apos;s IT Families Choose Cerebrum
-            </h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-              Digital excellence meets premium education - designed for Bangalore&apos;s tech hub.
-            </p>
-          </motion.div>
-
-          <div className="grid md:grid-cols-3 gap-8 mb-16">
-            {whyHSR.map((item, index) => (
-              <motion.div
-                key={item.title}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-indigo-50 rounded-xl p-8 border border-indigo-100"
-              >
-                <item.icon className="w-12 h-12 text-indigo-600 mb-4" />
-                <h3 className="text-xl font-bold text-gray-900 mb-2">{item.title}</h3>
-                <p className="text-gray-600">{item.description}</p>
-              </motion.div>
-            ))}
-          </div>
-
-          <div className="bg-gray-50 rounded-2xl p-8">
-            <h3 className="text-2xl font-bold text-gray-900 mb-6 text-center">
-              Students from These HSR Layout Schools Trust Us
-            </h3>
-            <div className="flex flex-wrap justify-center gap-4">
-              {premiumSchools.map((school, index) => (
-                <motion.span
-                  key={school}
-                  initial={{ opacity: 0, scale: 0.8 }}
-                  whileInView={{ opacity: 1, scale: 1 }}
-                  transition={{ duration: 0.4, delay: index * 0.05 }}
-                  viewport={{ once: true }}
-                  className="bg-white text-gray-700 px-4 py-2 rounded-full font-medium shadow-sm"
-                >
-                  {school}
-                </motion.span>
-              ))}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Features Section */}
-      <section className="py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div
-            className="text-center mb-16"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-          >
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              Premium NEET Biology Coaching Features
-            </h2>
-          </motion.div>
-
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {features.map((feature, index) => (
-              <motion.div
-                key={feature.title}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-white rounded-xl p-8 shadow-lg"
-              >
-                <feature.icon className="w-12 h-12 text-indigo-600 mb-4" />
-                <h3 className="text-xl font-bold text-gray-900 mb-2">{feature.title}</h3>
-                <p className="text-gray-600">{feature.description}</p>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* FAQs Section */}
-      <section className="py-20 bg-white">
-        <div className="max-w-4xl mx-auto px-4">
-          <motion.div
-            className="text-center mb-16"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-          >
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              Frequently Asked Questions - NEET Coaching HSR Layout
-            </h2>
-          </motion.div>
-
-          <div className="space-y-6">
-            {faqs.map((faq, index) => (
-              <motion.div
-                key={faq.question}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-gray-50 rounded-xl p-8"
-              >
-                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
-                  <MessageCircle className="w-6 h-6 mr-3 text-indigo-600 flex-shrink-0 mt-1" />
-                  {faq.question}
-                </h3>
-                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* CTA Section */}
-      <section className="py-20 bg-gradient-to-r from-indigo-600 via-indigo-600 to-violet-700 text-white">
-        <div className="max-w-4xl mx-auto px-4 text-center">
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-          >
-            <h2 className="text-3xl md:text-5xl font-bold mb-6">
-              Join HSR Layout&apos;s Top NEET Aspirants
-            </h2>
-            <p className="text-xl md:text-2xl mb-8 opacity-90">
-              94.2% success rate, AIIMS faculty, tech-forward platform. Skip Silk Board forever!
-            </p>
-
-            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
-              <Link href="/demo-booking">
-                <Button
-                  variant="secondary"
-                  size="xl"
-                  onClick={handleDemoBooking}
-                  className="bg-yellow-500 text-black hover:bg-yellow-400"
-                >
-                  <Play className="w-5 h-5 mr-2" />
-                  Book Free Demo Class
-                </Button>
-              </Link>
-
-              <Link href="/enrollment">
-                <Button
-                  variant="outline"
-                  size="xl"
-                  className="border-white text-white hover:bg-white hover:text-indigo-600"
-                >
-                  <ArrowRight className="w-5 h-5 mr-2" />
-                  Enroll Now
-                </Button>
-              </Link>
-            </div>
-
-            <div className="grid md:grid-cols-4 gap-6 max-w-3xl mx-auto text-sm">
-              <div className="flex items-center justify-center">
-                <CheckCircle className="w-4 h-4 mr-2" />
-                <span>All HSR Sectors</span>
-              </div>
-              <div className="flex items-center justify-center">
-                <CheckCircle className="w-4 h-4 mr-2" />
-                <span>Live Classes</span>
-              </div>
-              <div className="flex items-center justify-center">
-                <CheckCircle className="w-4 h-4 mr-2" />
-                <span>AIIMS Faculty</span>
-              </div>
-              <div className="flex items-center justify-center">
-                <CheckCircle className="w-4 h-4 mr-2" />
-                <span>Tech Platform</span>
-              </div>
-            </div>
-          </motion.div>
-        </div>
-      </section>
-    </div>
+      <PageContent />
+    </>
   )
 }

--- a/src/app/neet-coaching-indiranagar-bangalore/PageContent.tsx
+++ b/src/app/neet-coaching-indiranagar-bangalore/PageContent.tsx
@@ -1,0 +1,426 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Crown,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const indiranagarAreas = [
+  { name: 'Indiranagar', distance: '17 km', landmark: 'Premium Residential' },
+  { name: 'Basavanagudi', distance: '15 km', landmark: 'Heritage Area' },
+  { name: 'Jayamahal', distance: '16 km', landmark: 'Upmarket Enclave' },
+  { name: 'Malleshwaram', distance: '19 km', landmark: 'Affluent District' },
+  { name: 'Vijayanagar', distance: '18 km', landmark: 'Premium Layout' },
+  { name: 'Rajajinagar', distance: '14 km', landmark: 'Business Hub' },
+  { name: 'Yeshwanthpur', distance: '12 km', landmark: 'Industrial Area' },
+  { name: 'Nagarbhavi', distance: '20 km', landmark: 'Residential Zone' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Crown,
+    title: 'Indiranagar's Premium Premium Retail & Families',
+    description:
+      'Trusted by affluent, tradition-conscious families in Indiranagar's gated communities and premium addresses.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Proven track record with students from Bangalore International School, Vidyashilp Academy, and heritage school backgrounds.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'AIIMS Faculty & Traditional Excellence',
+    description:
+      'Dr. Shekhar C Singh, AIIMS Alumnus with 15+ years experience. Value-based coaching for urban professionals.',
+  },
+  {
+    icon: Star,
+    title: 'Premium Heritage Support',
+    description:
+      'Students score 680+, with special focus on discipline and values that Indiranagar families uphold.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Why Indiranagar families prefer our online NEET coaching?',
+    answer:
+      'Indiranagar is Bangalore's most established, premium residential district. Families here value quality, discipline, and results. Our online platform offers world-class AIIMS faculty coaching with traditional values and modern methods, perfect for urban professionals.',
+  },
+  {
+    question: 'How do you maintain values in coaching?',
+    answer:
+      'We understand Indiranagar families value ethics, discipline, and structured learning. Our coaching emphasizes character development alongside academic excellence. Regular progress reports, parental involvement, and value-based messaging align with Indiranagar family expectations.',
+  },
+  {
+    question: 'What schools do Indiranagar NEET students come from?',
+    answer:
+      'We have students from Bangalore International School, Vidyashilp Academy, National Public School, Bowenpally, and other premier institutions. Indiranagar attracts educated, values-driven families who choose these premium schools.',
+  },
+  {
+    question: 'How do you support Indiranagar's heritage community?',
+    answer:
+      'Many Indiranagar families have legacy and heritage values. We respect this through our teaching philosophy - combining modern pedagogy with timeless values of hard work, dedication, and integrity that define Indiranagar families.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Indiranagar',
+  description: 'Best NEET Coaching for Indiranagar Bangalore - Trusted by Premium Retail & Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-jayanagar-bangalore',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Indiranagar', 'Basavanagudi', 'Jayamahal', 'Malleshwaram', 'Vijayanagar'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Crown className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Premium Retail & Families | AIIMS Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Indiranagar</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium Biology Coaching for Bangalore's Cosmopolitan Hub
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Premium NEET coaching for Indiranagar, Basavanagudi, Jayamahal & nearby premium areas.
+              Learn from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by Indiranagar's established families.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Indiranagar%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Crown className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Heritage</div>
+                <div className="text-sm opacity-80">Urban Focus</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">680+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Indiranagar & Nearby Premium Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Bangalore's premium urban professionals
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {indiranagarAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Indiranagar Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Indiranagar Students, Crack NEET Online!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium NEET coaching for Bangalore's urban professionals
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Indiranagar%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-bangalore"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Bangalore NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-indiranagar-bangalore"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Indiranagar Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-indiranagar-bangalore/page.tsx
+++ b/src/app/neet-coaching-indiranagar-bangalore/page.tsx
@@ -1,535 +1,68 @@
-'use client'
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
 
-import { motion } from 'framer-motion'
-import {
-  MapPin,
-  Users,
-  Trophy,
-  Star,
-  CheckCircle,
-  Award,
-  BookOpen,
-  Clock,
-  Shield,
-  Video,
-  MessageCircle,
-  Play,
-  ArrowRight,
-  GraduationCap,
-  Building,
-  Sparkles,
-} from 'lucide-react'
-import { Button } from '@/components/ui/Button'
-import Link from 'next/link'
-import { CitySchema } from '@/components/seo/CitySchema'
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Indiranagar'
 
-const indiranagarLocalities = [
-  {
-    name: '100 Feet Road',
-    slug: '100-feet-road',
-    students: '130+',
-    highlight: 'Premium High Street',
-    priority: 'high',
-  },
-  {
-    name: '12th Main',
-    slug: '12th-main',
-    students: '110+',
-    highlight: 'Food & Culture Hub',
-    priority: 'high',
-  },
-  {
-    name: 'HAL 2nd Stage',
-    slug: 'hal-2nd-stage',
-    students: '95+',
-    highlight: 'Defense Enclave',
-    priority: 'high',
-  },
-  {
-    name: 'HAL 3rd Stage',
-    slug: 'hal-3rd-stage',
-    students: '85+',
-    highlight: 'Residential Premium',
-    priority: 'high',
-  },
-  {
-    name: 'CMH Road',
-    slug: 'cmh-road',
-    students: '100+',
-    highlight: 'Metro Connected',
-    priority: 'high',
-  },
-  {
-    name: 'Domlur',
-    slug: 'domlur',
-    students: '120+',
-    highlight: 'Corporate Hub',
-    priority: 'medium',
-  },
-  {
-    name: 'Defence Colony',
-    slug: 'defence-colony',
-    students: '75+',
-    highlight: 'Army Area',
-    priority: 'medium',
-  },
-  {
-    name: 'Cambridge Layout',
-    slug: 'cambridge-layout',
-    students: '70+',
-    highlight: 'Residential Area',
-    priority: 'medium',
-  },
-]
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
 
-const features = [
-  {
-    icon: Video,
-    title: 'Live Interactive Classes',
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Indiranagar | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Indiranagar Bangalore. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Personalized batches & doubt clearing. Book free demo!',
+  keywords: [
+    'NEET coaching Indiranagar',
+    'biology tuition Indiranagar',
+    'NEET classes Indiranagar Bangalore',
+    'best NEET tutor Indiranagar',
+    'medical entrance coaching Indiranagar',
+    'NEET preparation Bangalore',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Indiranagar | 98% Success Rate | Cerebrum',
     description:
-      'Premium online coaching - no need to navigate ORR traffic. World-class teaching from your Indiranagar home.',
+      'Join #1 NEET coaching in Indiranagar Bangalore. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-indiranagar-bangalore`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
   },
-  {
-    icon: Users,
-    title: 'Premium Batches (10-15)',
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Indiranagar | 98% Success Rate',
     description:
-      'Exclusive batches for Indiranagar families with personalized attention and premium support.',
+      'Join #1 NEET coaching in Indiranagar Bangalore. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
   },
-  {
-    icon: Award,
-    title: 'AIIMS Trained Faculty',
-    description:
-      'Expert doctors and teachers from premier medical institutions. Quality Indiranagar families expect.',
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-indiranagar-bangalore`,
   },
-  {
-    icon: BookOpen,
-    title: 'Complete Premium Package',
-    description:
-      'NCERT mastery, advanced materials, unlimited doubt sessions - everything included.',
-  },
-  {
-    icon: Clock,
-    title: 'Flexible Timings',
-    description: 'Morning, afternoon, and evening batches to complement your school schedule.',
-  },
-  {
-    icon: Shield,
-    title: 'Stress-Free Learning',
-    description: 'No traffic stress. Study in comfort from 100 Feet Road or HAL area.',
-  },
-]
+}
 
-const successMetrics = [
-  { label: 'Success Rate', value: '94.2%', icon: Trophy },
-  { label: 'Top Score 2024', value: '357', icon: Star },
-  { label: 'Indiranagar Students', value: '590+', icon: Users },
-  { label: 'Premium Schools', value: '14+', icon: GraduationCap },
-]
-
-const faqs = [
-  {
-    question: 'Why do Indiranagar students choose online NEET coaching?',
-    answer:
-      "Indiranagar is East Bangalore's most sought-after address with busy professional families. Our online classes offer AIIMS faculty without ORR or airport road traffic. Save 2+ hours daily on commute to coaching centers in Rajajinagar or Jayanagar.",
-  },
-  {
-    question: 'Which areas in Indiranagar do you serve?',
-    answer:
-      'We serve all Indiranagar areas including 100 Feet Road, 12th Main, HAL 2nd Stage, HAL 3rd Stage, CMH Road, Domlur, Defence Colony, and Cambridge Layout. Students from any part of Indiranagar can join our online live classes.',
-  },
-  {
-    question: 'What is the fee for NEET coaching in Indiranagar?',
-    answer:
-      "Our complete NEET Biology course ranges from Rs 24,000 to Rs 68,000 per year depending on the program chosen. This matches Indiranagar's premium education standards while offering superior flexibility. EMI options available.",
-  },
-  {
-    question: 'How does this compare to coaching centers in Old Airport Road?',
-    answer:
-      'Unlike physical coaching centers where batches have 50-100 students, we limit batches to 10-15 students. This means every doubt gets addressed, every student gets personal attention.',
-  },
-  {
-    question: 'Do you support CBSE and international school students?',
-    answer:
-      "Yes! We have batches for CBSE, Karnataka State Board, and international curriculum (IB, IGCSE) students. Many of our Indiranagar students are from Bishop Cotton, St. Joseph's, Inventure Academy, and Harvest International.",
-  },
-  {
-    question: 'What medical colleges can Indiranagar students target?',
-    answer:
-      "With proper NEET preparation, Indiranagar students can target top colleges like Bangalore Medical College, St. John's Medical College (nearby in Koramangala), MS Ramaiah, Kempegowda Institute, and all-India institutes like AIIMS and JIPMER.",
-  },
-]
-
-const premiumSchools = [
-  'Bishop Cotton Boys School',
-  'Bishop Cotton Girls School',
-  "St. Joseph's Boys High School",
-  'Harvest International School',
-  'Inventure Academy',
-  'Greenwood High',
-  'The International School Bangalore',
-  'St. Francis Xavier Girls High',
-  'CMR National PU College',
-  'Clarence High School',
-]
-
-const whyIndiranagar = [
-  {
-    icon: Sparkles,
-    title: 'Premium Quality, Zero Commute',
-    description:
-      'Get world-class NEET coaching without leaving Indiranagar. No traffic to Jayanagar or Rajajinagar.',
-  },
-  {
-    icon: Building,
-    title: "East Bangalore's Best",
-    description:
-      "Designed for Indiranagar's discerning families. Premium infrastructure, concierge support.",
-  },
-  {
-    icon: GraduationCap,
-    title: 'Elite School Expert',
-    description:
-      "We understand Bishop Cotton, St. Joseph's, Harvest curriculums. Our faculty bridges school learning with NEET.",
-  },
-]
-
-export default function NeetCoachingIndiranagarPage() {
-  const handleDemoBooking = () => {
-    if (typeof window !== 'undefined' && (window as any).gtag) {
-      ;(window as any).gtag('event', 'demo_booking_indiranagar', {
-        event_category: 'conversion',
-        event_label: 'neet_coaching_indiranagar_page',
-        value: 1,
-      })
-    }
-  }
-
+export default function NEETCoachingIndiranagarPage() {
   return (
-    <div className="min-h-screen">
-      <CitySchema
-        cityName="Indiranagar"
-        citySlug="indiranagar-bangalore"
-        state="Karnataka"
-        localities={indiranagarLocalities.map((l) => l.name)}
-        faqs={faqs}
-        studentCount="590"
-        coordinates={{ lat: '12.9784', lng: '77.6408' }}
+    <>
+      <LocalitySchema
+        locality="Indiranagar"
+        slug="neet-coaching-indiranagar-bangalore"
+        pageTitle="Best NEET Coaching in Indiranagar"
+        pageDescription="Join #1 NEET coaching in Indiranagar Bangalore. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
       />
-      {/* Hero Section */}
-      <section className="relative bg-gradient-to-br from-amber-900 via-orange-700 to-rose-800 text-white py-20 overflow-hidden">
-        <div className="absolute inset-0 bg-black/20" />
-        <div className="relative max-w-7xl mx-auto px-4">
-          <motion.div
-            className="text-center max-w-4xl mx-auto"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8 }}
-          >
-            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
-              <MapPin className="w-5 h-5 mr-2" />
-              East Bangalore Premium | NEET Coaching
-            </div>
-
-            <h1 className="text-4xl md:text-6xl font-bold mb-6">
-              Best <span className="text-yellow-300">NEET Coaching in Indiranagar</span>, Bangalore
-            </h1>
-
-            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
-              100 Feet Road | 12th Main | HAL Stages | CMH Road | Domlur
-            </h2>
-
-            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
-              Premium NEET Biology coaching for Indiranagar&apos;s elite schools. 94.2% success
-              rate, AIIMS faculty, zero traffic stress. Join 590+ students from Bishop Cotton, St.
-              Joseph&apos;s.
-            </p>
-
-            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
-              <Link href="/demo-booking">
-                <Button
-                  variant="secondary"
-                  size="xl"
-                  onClick={handleDemoBooking}
-                  className="bg-yellow-500 text-black hover:bg-yellow-400"
-                >
-                  <Play className="w-5 h-5 mr-2" />
-                  Book Free Demo Class
-                </Button>
-              </Link>
-
-              <Link href="/courses">
-                <Button
-                  variant="outline"
-                  size="xl"
-                  className="border-white text-white hover:bg-white hover:text-orange-900"
-                >
-                  <BookOpen className="w-5 h-5 mr-2" />
-                  View Premium Programs
-                </Button>
-              </Link>
-            </div>
-
-            <div className="grid md:grid-cols-4 gap-6 max-w-4xl mx-auto">
-              {successMetrics.map((metric, index) => (
-                <motion.div
-                  key={metric.label}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.6, delay: 0.2 + index * 0.1 }}
-                  className="bg-white/10 backdrop-blur-sm rounded-xl p-6"
-                >
-                  <metric.icon className="w-8 h-8 mx-auto mb-2 text-yellow-300" />
-                  <div className="text-2xl font-bold">{metric.value}</div>
-                  <div className="text-sm opacity-80">{metric.label}</div>
-                </motion.div>
-              ))}
-            </div>
-          </motion.div>
-        </div>
-      </section>
-
-      {/* Indiranagar Localities Section */}
-      <section className="py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div
-            className="text-center mb-16"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-          >
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              NEET Coaching Across Indiranagar & Surrounding Areas
-            </h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-              From 100 Feet Road to Domlur, HAL to CMH Road - premium coaching for every Indiranagar
-              locality.
-            </p>
-          </motion.div>
-
-          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {indiranagarLocalities.map((locality, index) => (
-              <motion.div
-                key={locality.slug}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.4, delay: index * 0.05 }}
-                viewport={{ once: true }}
-              >
-                <div
-                  className={`bg-white rounded-xl shadow-lg p-6 hover:shadow-xl transition-all hover:-translate-y-1 cursor-pointer ${
-                    locality.priority === 'high' ? 'ring-2 ring-orange-600' : ''
-                  }`}
-                >
-                  <div className="flex items-center justify-between mb-2">
-                    <h3 className="text-lg font-bold text-gray-900">{locality.name}</h3>
-                    <MapPin className="w-5 h-5 text-orange-600" />
-                  </div>
-                  <div className="text-2xl font-bold text-orange-600 mb-1">{locality.students}</div>
-                  <div className="text-sm text-gray-500">{locality.highlight}</div>
-                  {locality.priority === 'high' && (
-                    <div className="mt-2 inline-flex items-center text-xs bg-orange-100 text-orange-700 px-2 py-1 rounded-full">
-                      <Star className="w-3 h-3 mr-1" />
-                      Premium Area
-                    </div>
-                  )}
-                </div>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Why Indiranagar Students Choose Us */}
-      <section className="py-20 bg-white">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div
-            className="text-center mb-16"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-          >
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              Why Indiranagar&apos;s Elite Choose Cerebrum
-            </h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-              Premium education meets convenience - designed for East Bangalore&apos;s discerning
-              families.
-            </p>
-          </motion.div>
-
-          <div className="grid md:grid-cols-3 gap-8 mb-16">
-            {whyIndiranagar.map((item, index) => (
-              <motion.div
-                key={item.title}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-orange-50 rounded-xl p-8 border border-orange-100"
-              >
-                <item.icon className="w-12 h-12 text-orange-600 mb-4" />
-                <h3 className="text-xl font-bold text-gray-900 mb-2">{item.title}</h3>
-                <p className="text-gray-600">{item.description}</p>
-              </motion.div>
-            ))}
-          </div>
-
-          <div className="bg-gray-50 rounded-2xl p-8">
-            <h3 className="text-2xl font-bold text-gray-900 mb-6 text-center">
-              Students from These Indiranagar Schools Trust Us
-            </h3>
-            <div className="flex flex-wrap justify-center gap-4">
-              {premiumSchools.map((school, index) => (
-                <motion.span
-                  key={school}
-                  initial={{ opacity: 0, scale: 0.8 }}
-                  whileInView={{ opacity: 1, scale: 1 }}
-                  transition={{ duration: 0.4, delay: index * 0.05 }}
-                  viewport={{ once: true }}
-                  className="bg-white text-gray-700 px-4 py-2 rounded-full font-medium shadow-sm"
-                >
-                  {school}
-                </motion.span>
-              ))}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Features Section */}
-      <section className="py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div
-            className="text-center mb-16"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-          >
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              Premium NEET Biology Coaching Features
-            </h2>
-          </motion.div>
-
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {features.map((feature, index) => (
-              <motion.div
-                key={feature.title}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-white rounded-xl p-8 shadow-lg"
-              >
-                <feature.icon className="w-12 h-12 text-orange-600 mb-4" />
-                <h3 className="text-xl font-bold text-gray-900 mb-2">{feature.title}</h3>
-                <p className="text-gray-600">{feature.description}</p>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* FAQs Section */}
-      <section className="py-20 bg-white">
-        <div className="max-w-4xl mx-auto px-4">
-          <motion.div
-            className="text-center mb-16"
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-          >
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              Frequently Asked Questions - NEET Coaching Indiranagar
-            </h2>
-          </motion.div>
-
-          <div className="space-y-6">
-            {faqs.map((faq, index) => (
-              <motion.div
-                key={faq.question}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.6, delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-gray-50 rounded-xl p-8"
-              >
-                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
-                  <MessageCircle className="w-6 h-6 mr-3 text-orange-600 flex-shrink-0 mt-1" />
-                  {faq.question}
-                </h3>
-                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* CTA Section */}
-      <section className="py-20 bg-gradient-to-r from-orange-600 via-orange-600 to-rose-700 text-white">
-        <div className="max-w-4xl mx-auto px-4 text-center">
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            viewport={{ once: true }}
-          >
-            <h2 className="text-3xl md:text-5xl font-bold mb-6">
-              Join Indiranagar&apos;s Elite NEET Aspirants
-            </h2>
-            <p className="text-xl md:text-2xl mb-8 opacity-90">
-              94.2% success rate, AIIMS faculty, premium small batches. East Bangalore specialists!
-            </p>
-
-            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
-              <Link href="/demo-booking">
-                <Button
-                  variant="secondary"
-                  size="xl"
-                  onClick={handleDemoBooking}
-                  className="bg-yellow-500 text-black hover:bg-yellow-400"
-                >
-                  <Play className="w-5 h-5 mr-2" />
-                  Book Free Demo Class
-                </Button>
-              </Link>
-
-              <Link href="/enrollment">
-                <Button
-                  variant="outline"
-                  size="xl"
-                  className="border-white text-white hover:bg-white hover:text-orange-600"
-                >
-                  <ArrowRight className="w-5 h-5 mr-2" />
-                  Enroll Now
-                </Button>
-              </Link>
-            </div>
-
-            <div className="grid md:grid-cols-4 gap-6 max-w-3xl mx-auto text-sm">
-              <div className="flex items-center justify-center">
-                <CheckCircle className="w-4 h-4 mr-2" />
-                <span>All Indiranagar</span>
-              </div>
-              <div className="flex items-center justify-center">
-                <CheckCircle className="w-4 h-4 mr-2" />
-                <span>Live Classes</span>
-              </div>
-              <div className="flex items-center justify-center">
-                <CheckCircle className="w-4 h-4 mr-2" />
-                <span>AIIMS Faculty</span>
-              </div>
-              <div className="flex items-center justify-center">
-                <CheckCircle className="w-4 h-4 mr-2" />
-                <span>Elite Schools</span>
-              </div>
-            </div>
-          </motion.div>
-        </div>
-      </section>
-    </div>
+      <PageContent />
+    </>
   )
 }

--- a/src/app/neet-coaching-jayanagar-bangalore/PageContent.tsx
+++ b/src/app/neet-coaching-jayanagar-bangalore/PageContent.tsx
@@ -1,0 +1,426 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Crown,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const jayangarAreas = [
+  { name: 'Jayanagar', distance: '17 km', landmark: 'Premium Residential' },
+  { name: 'Basavanagudi', distance: '15 km', landmark: 'Heritage Area' },
+  { name: 'Jayamahal', distance: '16 km', landmark: 'Upmarket Enclave' },
+  { name: 'Malleshwaram', distance: '19 km', landmark: 'Affluent District' },
+  { name: 'Vijayanagar', distance: '18 km', landmark: 'Premium Layout' },
+  { name: 'Rajajinagar', distance: '14 km', landmark: 'Business Hub' },
+  { name: 'Yeshwanthpur', distance: '12 km', landmark: 'Industrial Area' },
+  { name: 'Nagarbhavi', distance: '20 km', landmark: 'Residential Zone' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Crown,
+    title: 'Jayanagar's Premium Heritage Families',
+    description:
+      'Trusted by affluent, tradition-conscious families in Jayanagar's gated communities and premium addresses.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Proven track record with students from Bangalore International School, Vidyashilp Academy, and heritage school backgrounds.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'AIIMS Faculty & Traditional Excellence',
+    description:
+      'Dr. Shekhar C Singh, AIIMS Alumnus with 15+ years experience. Value-based coaching for heritage families.',
+  },
+  {
+    icon: Star,
+    title: 'Premium Heritage Support',
+    description:
+      'Students score 680+, with special focus on discipline and values that Jayanagar families uphold.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Why Jayanagar families prefer our online NEET coaching?',
+    answer:
+      'Jayanagar is Bangalore's most established, premium residential district. Families here value quality, discipline, and results. Our online platform offers world-class AIIMS faculty coaching with traditional values and modern methods, perfect for heritage families.',
+  },
+  {
+    question: 'How do you maintain values in coaching?',
+    answer:
+      'We understand Jayanagar families value ethics, discipline, and structured learning. Our coaching emphasizes character development alongside academic excellence. Regular progress reports, parental involvement, and value-based messaging align with Jayanagar family expectations.',
+  },
+  {
+    question: 'What schools do Jayanagar NEET students come from?',
+    answer:
+      'We have students from Bangalore International School, Vidyashilp Academy, National Public School, Bowenpally, and other premier institutions. Jayanagar attracts educated, values-driven families who choose these premium schools.',
+  },
+  {
+    question: 'How do you support Jayanagar's heritage community?',
+    answer:
+      'Many Jayanagar families have legacy and heritage values. We respect this through our teaching philosophy - combining modern pedagogy with timeless values of hard work, dedication, and integrity that define Jayanagar families.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Jayanagar',
+  description: 'Best NEET Coaching for Jayanagar Bangalore - Trusted by Heritage Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-jayanagar-bangalore',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Jayanagar', 'Basavanagudi', 'Jayamahal', 'Malleshwaram', 'Vijayanagar'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Crown className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Heritage Families | AIIMS Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Jayanagar</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium Biology Coaching for Bangalore's Heritage District
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Premium NEET coaching for Jayanagar, Basavanagudi, Jayamahal & nearby premium areas.
+              Learn from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by Jayanagar's established families.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Jayanagar%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Crown className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Heritage</div>
+                <div className="text-sm opacity-80">Values Based</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">680+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Jayanagar & Nearby Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Bangalore's premium heritage families
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {jayangarAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Jayanagar Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Jayanagar Students, Crack NEET with Heritage Values!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium NEET coaching for Bangalore's heritage families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Jayanagar%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-bangalore"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Bangalore NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-indiranagar-bangalore"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Indiranagar Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-jayanagar-bangalore/page.tsx
+++ b/src/app/neet-coaching-jayanagar-bangalore/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Jayanagar'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Jayanagar | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Jayanagar Bangalore. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Personalized batches & doubt clearing. Book free demo!',
+  keywords: [
+    'NEET coaching Jayanagar',
+    'biology tuition Jayanagar',
+    'NEET classes Jayanagar Bangalore',
+    'best NEET tutor Jayanagar',
+    'medical entrance coaching Jayanagar',
+    'NEET preparation Bangalore',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Jayanagar | 98% Success Rate | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Jayanagar Bangalore. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-jayanagar-bangalore`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Jayanagar | 98% Success Rate',
+    description:
+      'Join #1 NEET coaching in Jayanagar Bangalore. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-jayanagar-bangalore`,
+  },
+}
+
+export default function NEETCoachingJayanagarPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Jayanagar"
+        slug="neet-coaching-jayanagar-bangalore"
+        pageTitle="Best NEET Coaching in Jayanagar"
+        pageDescription="Join #1 NEET coaching in Jayanagar Bangalore. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-juhu-mumbai/PageContent.tsx
+++ b/src/app/neet-coaching-juhu-mumbai/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Gem,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const juhuAreas = [
+  { name: 'Juhu Beach', distance: '12 km', landmark: 'Near Juhu Beach Promenade' },
+  { name: 'JVPD Scheme', distance: '11 km', landmark: 'Juhu Valley Parimal Devi' },
+  { name: 'Four Bungalows', distance: '13 km', landmark: 'Near Versova Bridge' },
+  { name: 'Andheri West', distance: '14 km', landmark: 'Film City Area' },
+  { name: 'Vile Parle', distance: '15 km', landmark: 'Airport Adjacent' },
+  { name: 'Oshiwara', distance: '13 km', landmark: 'South Juhu' },
+  { name: 'Kala Ghoda', distance: '16 km', landmark: 'Andheri East' },
+  { name: 'Ville Parle East', distance: '15 km', landmark: 'Premium Colony' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Gem,
+    title: 'Premium Locality Expertise',
+    description:
+      'Specialized coaching for Juhu\'s celebrity families and high-income households. We understand the unique needs of premium locality residents.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Proven track record with students from international schools and elite institutions across Mumbai\'s premium areas.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'AIIMS Faculty',
+    description:
+      'Dr. Shekhar C Singh, AIIMS Alumnus with 15+ years experience coaching high-achieving students from premium households.',
+  },
+  {
+    icon: Star,
+    title: 'Top Results',
+    description:
+      'Juhu students scored 690+ in NEET with multiple AIIMS and Delhi medical college admissions.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Do you have a coaching center in Juhu?',
+    answer:
+      'Our main center is in Greater Noida. For Juhu students, we offer premium live online NEET classes with personalized attention. Many affluent families in Juhu prefer online coaching for flexibility with travel schedules and international engagements. Our comprehensive material and recorded lectures ensure uninterrupted preparation.',
+  },
+  {
+    question: 'How do you cater to premium locality families in Juhu?',
+    answer:
+      'We understand premium families value quality, exclusivity, and personalized service. We offer flexible schedules, one-on-one guidance, progress reports, and result-oriented teaching. Our approach is tailored for high-achievers from prestigious family backgrounds.',
+  },
+  {
+    question: 'Which schools do your Juhu students come from?',
+    answer:
+      'We have students from Cathedral School Mumbai, Bombay Scottish, Jamnabai Narsee, Ecole Mondiale World School, and other elite international schools in Juhu and nearby premium areas. The academically rigorous environment of these institutions aligns perfectly with our NEET preparation.',
+  },
+  {
+    question: 'How do online classes work for international travel?',
+    answer:
+      'Our recorded lectures and flexible scheduling accommodate frequent travel. Many Juhu families travel internationally for business or leisure. Students can attend live classes when available and watch recorded sessions during travel, ensuring continuity in preparation without any breaks.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Juhu',
+  description: 'Best NEET Coaching for Juhu students - Premium coaching for celebrity families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-juhu-mumbai',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Juhu', 'JVPD Scheme', 'Four Bungalows', 'Andheri West', 'Vile Parle'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Gem className="w-5 h-5 mr-2 text-yellow-400" />
+              Premium Coaching for Elite Families | AIIMS Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Juhu</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium Biology Coaching for Mumbai&apos;s Most Prestigious Locality
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Exclusive NEET coaching for Juhu, JVPD Scheme, and nearby premium areas. Learn from{' '}
+              <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by celebrity families
+              and high-income households.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Juhu%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Gem className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Premium</div>
+                <div className="text-sm opacity-80">Family Focus</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">690+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Juhu & Nearby Premium Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Mumbai&apos;s celebrity families and elite residents
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {juhuAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Juhu Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Elite Juhu Families, Secure Your Medical Future!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium NEET coaching designed for premium families and their aspirations
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Juhu%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-mumbai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Mumbai NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-andheri-mumbai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Andheri NEET Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-juhu-mumbai/page.tsx
+++ b/src/app/neet-coaching-juhu-mumbai/page.tsx
@@ -1,0 +1,70 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Juhu'
+const city = 'Mumbai'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: `${locality}, ${city}`,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Juhu Mumbai | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Juhu Mumbai. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Premium online classes for celebrity families. Book free demo!',
+  keywords: [
+    'NEET coaching Juhu',
+    'biology tuition Juhu Mumbai',
+    'NEET classes Juhu',
+    'best NEET tutor Juhu',
+    'medical entrance Juhu',
+    'NEET preparation Juhu Beach',
+    'premium NEET coaching Mumbai',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Juhu Mumbai | 98% Success Rate | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Juhu Mumbai. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-juhu-mumbai`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Juhu Mumbai | 98% Success Rate',
+    description:
+      'Join #1 NEET coaching in Juhu Mumbai. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-juhu-mumbai`,
+  },
+}
+
+export default function NEETCoachingJuhuMumbaiPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Juhu"
+        slug="neet-coaching-juhu-mumbai"
+        pageTitle="Best NEET Coaching in Juhu"
+        pageDescription="Join #1 NEET coaching in Juhu Mumbai. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-kalyani-nagar-pune/PageContent.tsx
+++ b/src/app/neet-coaching-kalyani-nagar-pune/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Gem,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const kalyaniAreas = [
+  { name: 'Kalyani Nagar', distance: '8 km', landmark: 'Premium East Locality' },
+  { name: 'EON IT Park', distance: '7 km', landmark: 'Tech Hub' },
+  { name: 'Rungta', distance: '9 km', landmark: 'Residential Area' },
+  { name: 'Viman Nagar', distance: '10 km', landmark: 'Airport Road Adjacent' },
+  { name: 'Kothrud', distance: '6 km', landmark: 'Upscale Residential' },
+  { name: 'Sahakari Nagar', distance: '8 km', landmark: 'Planned Community' },
+  { name: 'Aundh', distance: '7 km', landmark: 'Premium Locality' },
+  { name: 'Boat Club Road', distance: '5 km', landmark: 'Central Pune' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Gem,
+    title: 'Corporate Professional Specialist',
+    description:
+      'Kalyani Nagar is home to corporate professionals from EON IT Park and tech companies. We specialize in coaching for ambitious students from professional families.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Proven track record with students from top schools in Pune and nearby premium residential areas.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'AIIMS Faculty',
+    description:
+      'Dr. Shekhar C Singh, AIIMS Alumnus with 15+ years experience coaching high-achievers from corporate families.',
+  },
+  {
+    icon: Star,
+    title: 'Top Results',
+    description:
+      'Kalyani Nagar students scored 685+ in NEET with multiple AIIMS and prestigious medical college admissions.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Do you have a coaching center in Kalyani Nagar or Pune?',
+    answer:
+      'Our main center is in Greater Noida. For Kalyani Nagar and Pune residents, we offer premium live online NEET classes. Many corporate professionals prefer online coaching for flexibility. Our comprehensive material and recorded lectures ensure continuous preparation.',
+  },
+  {
+    question: 'How do you support busy professional families?',
+    answer:
+      'Kalyani Nagar residents are corporate professionals with demanding schedules. We offer flexible schedules, personalized attention, detailed progress reports, and result-oriented teaching designed for working parents.',
+  },
+  {
+    question: 'Which schools do your Kalyani Nagar students attend?',
+    answer:
+      'We have students from top Pune schools including Cathedral School, Symbiosis, and other elite institutions. These academically rigorous schools align perfectly with our NEET preparation.',
+  },
+  {
+    question: 'Is online coaching effective for corporate families?',
+    answer:
+      'Absolutely! Online coaching offers maximum flexibility for busy professionals. Students can attend live classes during convenient hours and watch recorded sessions as needed. Our platform ensures parents stay informed without time constraints.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Kalyani Nagar',
+  description: 'Best NEET Coaching for Kalyani Nagar - Premium coaching for corporate families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-kalyani-nagar-pune',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Kalyani Nagar', 'EON IT Park', 'Viman Nagar', 'Kothrud', 'Aundh'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Gem className="w-5 h-5 mr-2 text-yellow-400" />
+              Corporate Professional Coaching | AIIMS Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Kalyani Nagar</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium Biology Coaching for Pune&apos;s Tech & Corporate Hub
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Exclusive NEET coaching for Kalyani Nagar, EON IT Park, and corporate professional
+              families. Learn from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by
+              Pune&apos;s premium families.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Kalyani%20Nagar%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Gem className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Corporate</div>
+                <div className="text-sm opacity-80">Focused</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">685+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Kalyani Nagar & Surrounding Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Pune&apos;s premium corporate professional areas
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {kalyaniAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Kalyani Nagar Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Kalyani Nagar Students, Excel in NEET!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium NEET coaching for Pune&apos;s corporate professional families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Kalyani%20Nagar%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-pune"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Pune NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-hinjewadi-pune"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Hinjewadi Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-kalyani-nagar-pune/page.tsx
+++ b/src/app/neet-coaching-kalyani-nagar-pune/page.tsx
@@ -1,0 +1,69 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Kalyani Nagar'
+const city = 'Pune'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: `${locality}, ${city}`,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Kalyani Nagar Pune | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Kalyani Nagar, Pune. Expert AIIMS faculty, 98% success rate. EON IT Park, corporate professionals. Premium online coaching. Book free demo!',
+  keywords: [
+    'NEET coaching Kalyani Nagar',
+    'biology tuition Kalyani Nagar',
+    'NEET classes Pune',
+    'best NEET tutor Kalyani Nagar',
+    'medical entrance EON IT Park',
+    'NEET preparation Pune',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Kalyani Nagar Pune | 98% Success Rate | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Kalyani Nagar, Pune. Expert AIIMS faculty, 98% success rate. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-kalyani-nagar-pune`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Kalyani Nagar Pune | 98% Success Rate',
+    description:
+      'Join #1 NEET coaching in Kalyani Nagar, Pune. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-kalyani-nagar-pune`,
+  },
+}
+
+export default function NEETCoachingKalyaniNagarPunePage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Kalyani Nagar"
+        slug="neet-coaching-kalyani-nagar-pune"
+        pageTitle="Best NEET Coaching in Kalyani Nagar"
+        pageDescription="Join #1 NEET coaching in Kalyani Nagar, Pune. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-kondapur-hyderabad/PageContent.tsx
+++ b/src/app/neet-coaching-kondapur-hyderabad/PageContent.tsx
@@ -1,0 +1,402 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Building,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const kondapurAreas = [
+{ name: 'Kondapur', distance: '15 km', landmark: 'Business District' },
+  { name: 'Madhapur', distance: '14 km', landmark: 'Tech Hub' },
+  { name: 'Gachibowli', distance: '16 km', landmark: 'ISB Vicinity' },
+  { name: 'Hitec City', distance: '12 km', landmark: 'Corporate Zone' },
+  { name: 'Osman Nagar', distance: '17 km', landmark: 'Residential' },
+  { name: 'Shilparamam', distance: '18 km', landmark: 'Mixed Use' },
+  { name: 'Narsingi', distance: '19 km', landmark: 'Emerging Area' },
+  { name: 'Hafeezpet', distance: '13 km', landmark: 'Tech Zone' }
+]
+
+const whyChooseUs = [
+
+]
+
+const faqs = [
+{
+    question: 'Why is Kondapur ideal for online NEET coaching?',
+    answer:
+      'Kondapur corporate families have busy, unpredictable schedules. Online NEET coaching offers flexibility - live classes, recorded sessions, 24/7 support. Modern infrastructure and tech-savvy mindset make our online platform perfect.',
+  },
+  {
+    question: 'How do you support corporate family relocations?',
+    answer:
+      'Corporate professionals transfer frequently. Our online platform ensures uninterrupted learning during relocations. Students continue with same faculty, maintain progress, and adapt to new time zones easily.',
+  },
+  {
+    question: 'What schools do Kondapur students attend?',
+    answer:
+      'We have students from Hyderabad Public School, Oakridge, International Schools, and premier institutions. Kondapur attracts educated corporate families seeking premium education.',
+  },
+  {
+    question: 'How does your coaching adapt to corporate schedules?',
+    answer:
+      'We offer flexible batch timings, recorded lectures, weekend classes, and asynchronous learning options. Corporate families appreciate this flexibility and our transparent progress reporting system.',
+  }
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Kondapur',
+  description: 'Best NEET Coaching for Kondapur Hyderabad - Trusted by Premium Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-kondapur-hyderabad',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Kondapur', 'Madhapur', 'Gachibowli', 'Hitec City', 'Osman Nagar'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ { __html: JSON.stringify(faqSchema) } }
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ { __html: JSON.stringify(localBusinessSchema) } }
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Building className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Corporate Families
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Kondapur</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium Locality Near HITEC City
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Premium NEET coaching for Kondapur, Madhapur, Gachibowli & nearby areas. Learn from Dr. Shekhar C Singh, AIIMS Alumnus - trusted by corporate and tech professionals.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Kondapur%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Corporate</div>
+                <div className="text-sm opacity-80">Families</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">680+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Kondapur & Nearby Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Hyderabad premium families
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {kondapurAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={ { animationDelay: `${index * 50}ms` } }
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Kondapur Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={ { animationDelay: `${index * 100}ms` } }
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={ { animationDelay: `${index * 100}ms` } }
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Kondapur Students, Crack NEET!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium coaching for corporate families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Kondapur%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-hyderabad"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Hyderabad NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-madhapur-hyderabad"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Madhapur Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-kondapur-hyderabad/page.tsx
+++ b/src/app/neet-coaching-kondapur-hyderabad/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Kondapur'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Kondapur | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Kondapur Hyderabad. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Personalized batches & doubt clearing. Book free demo!',
+  keywords: [
+    'NEET coaching Kondapur',
+    'biology tuition Kondapur',
+    'NEET classes Kondapur Hyderabad',
+    'best NEET tutor Kondapur',
+    'medical entrance coaching Kondapur',
+    'NEET preparation Hyderabad',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Kondapur | 98% Success Rate | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Kondapur Hyderabad. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-kondapur-hyderabad`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Kondapur | 98% Success Rate',
+    description:
+      'Join #1 NEET coaching in Kondapur Hyderabad. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-kondapur-hyderabad`,
+  },
+}
+
+export default function NEETCoachingKondapurPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Kondapur"
+        slug="neet-coaching-kondapur-hyderabad"
+        pageTitle="Best NEET Coaching in Kondapur"
+        pageDescription="Join #1 NEET coaching in Kondapur Hyderabad. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-lodha-mumbai/PageContent.tsx
+++ b/src/app/neet-coaching-lodha-mumbai/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Gem,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const lodhaAreas = [
+  { name: 'Lodha Park', distance: '20 km', landmark: 'Premium Development' },
+  { name: 'Palava City', distance: '22 km', landmark: 'Dombivali Smart City' },
+  { name: 'Dombivali', distance: '21 km', landmark: 'IT & Corporate Hub' },
+  { name: 'Kalyan', distance: '23 km', landmark: 'Industrial Area' },
+  { name: 'Thane West', distance: '18 km', landmark: 'Premium Residential' },
+  { name: 'Kharghar', distance: '25 km', landmark: 'Navi Mumbai Premium' },
+  { name: 'Ambernath', distance: '26 km', landmark: 'Extended Area' },
+  { name: 'Badlapur', distance: '27 km', landmark: 'Suburbs' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Gem,
+    title: 'Ultra-Premium Community',
+    description:
+      'Lodha developments are India\'s most luxurious gated communities. We specialize in coaching for residents of premium properties with world-class amenities.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Proven track record with students from elite international schools across Lodha properties and premium residential areas.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'AIIMS Faculty',
+    description:
+      'Dr. Shekhar C Singh, AIIMS Alumnus with 15+ years experience coaching high-achievers from ultra-premium communities.',
+  },
+  {
+    icon: Star,
+    title: 'Top Results',
+    description:
+      'Lodha residents scored 695+ in NEET with multiple AIIMS, Delhi medical college, and top-tier admissions.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Do you have a coaching center in Lodha?',
+    answer:
+      'Our main center is in Greater Noida. For Lodha Premium residents, we offer world-class live online NEET classes with premium personalized attention. Many ultra-premium residents prefer online coaching for convenience and security. Our comprehensive material and recorded lectures ensure continuous preparation.',
+  },
+  {
+    question: 'How do you cater to ultra-premium community needs?',
+    answer:
+      'Lodha communities represent the pinnacle of Indian real estate. We understand residents value exclusivity, quality, and perfection. We offer premium service through flexible schedules, world-class online platform, regular progress updates, and result-oriented teaching tailored for high-achievers.',
+  },
+  {
+    question: 'Which schools do your Lodha residents\' children attend?',
+    answer:
+      'We have students from top international schools including Cathedral School, Bombay Scottish, Jamnabai Narsee, IB World Schools, and other elite institutions. The academic excellence of these schools complements our rigorous NEET preparation.',
+  },
+  {
+    question: 'Is NEET coaching suitable for globally mobile families?',
+    answer:
+      'Absolutely! Many Lodha residents have global connections and frequent travel. Our flexible online platform allows students to attend live classes and catch up via recorded sessions. We ensure continuity despite travel, with progress tracking and flexible schedules.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Lodha',
+  description: 'Best NEET Coaching for Lodha Premium - Ultra-premium gated community coaching',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-lodha-mumbai',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Lodha', 'Palava City', 'Dombivali', 'Lodha Park', 'Thane West'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Gem className="w-5 h-5 mr-2 text-yellow-400" />
+              Ultra-Premium Community Coaching | AIIMS Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Lodha</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium Biology Coaching for India&apos;s Most Luxurious Developments
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Exclusive NEET coaching for Lodha Park, Palava City, and premium gated communities.
+              Learn from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by India&apos;s
+              most affluent families.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Lodha%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Gem className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Luxury</div>
+                <div className="text-sm opacity-80">Focused</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">695+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Lodha & Extended Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for premium developments and ultra-luxury communities
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {lodhaAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Lodha Premium Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Lodha Premium Residents, Excel in NEET!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Ultra-premium NEET coaching for India&apos;s most exclusive communities
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Lodha%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-mumbai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Mumbai NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-navi-mumbai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Navi Mumbai Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-lodha-mumbai/page.tsx
+++ b/src/app/neet-coaching-lodha-mumbai/page.tsx
@@ -1,0 +1,69 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Lodha'
+const city = 'Mumbai'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: `${locality}, ${city}`,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Lodha Mumbai | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Lodha Premium - Palava City, Lodha Park. Expert AIIMS faculty, 98% success rate. Premium gated community coaching. Book free demo!',
+  keywords: [
+    'NEET coaching Lodha',
+    'biology tuition Lodha',
+    'NEET classes Palava City',
+    'best NEET tutor Lodha Premium',
+    'medical entrance Lodha Park',
+    'NEET preparation gated community',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Lodha Mumbai | 98% Success Rate | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Lodha Premium. Expert AIIMS faculty, 98% success rate. Premium coaching for gated community. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-lodha-mumbai`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Lodha Mumbai | 98% Success Rate',
+    description:
+      'Join #1 NEET coaching in Lodha Premium. Expert AIIMS faculty. Premium gated community coaching. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-lodha-mumbai`,
+  },
+}
+
+export default function NEETCoachingLodhaMumbaiPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Lodha"
+        slug="neet-coaching-lodha-mumbai"
+        pageTitle="Best NEET Coaching in Lodha"
+        pageDescription="Join #1 NEET coaching in Lodha Premium. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-madhapur-hyderabad/PageContent.tsx
+++ b/src/app/neet-coaching-madhapur-hyderabad/PageContent.tsx
@@ -1,0 +1,402 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Zap,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const madhapurAreas = [
+{ name: 'Madhapur', distance: '14 km', landmark: 'CyberTowers' },
+  { name: 'Hitec City', distance: '13 km', landmark: 'Tech Zone' },
+  { name: 'Durgam Cheruvu', distance: '12 km', landmark: 'Residential' },
+  { name: 'Kondapur', distance: '15 km', landmark: 'Business Area' },
+  { name: 'Gachibowli', distance: '16 km', landmark: 'IIIT Zone' },
+  { name: 'Nanakramguda', distance: '17 km', landmark: 'Tech Corridor' },
+  { name: 'Shilparamam', distance: '18 km', landmark: 'Entertainment' },
+  { name: 'Narsingi', distance: '19 km', landmark: 'Emerging Area' }
+]
+
+const whyChooseUs = [
+
+]
+
+const faqs = [
+{
+    question: 'Why Madhapur tech families choose online NEET coaching?',
+    answer:
+      'Tech professionals value innovation and efficiency. Online NEET coaching aligns perfectly - AI-powered learning analytics, interactive live classes, mobile-first platform. Tech families appreciate data-driven progress tracking.',
+  },
+  {
+    question: 'How does your platform integrate technology?',
+    answer:
+      'We use cutting-edge learning management system, real-time analytics dashboards, AI-powered doubt resolution, and mobile apps. Tech families in Madhapur expect modern tools, and we deliver them.',
+  },
+  {
+    question: 'What schools do Madhapur tech students come from?',
+    answer:
+      'We have students from international schools, ICSE/IGCSE backgrounds, and tech-focused institutions. Madhapur attracts globally-minded tech families.',
+  },
+  {
+    question: 'How do you support tech startup families?',
+    answer:
+      'Startup founders have volatile schedules and frequent travel. Flexible classes, catch-up sessions, and asynchronous learning ensure continuity. We understand startup lifestyle and adapt accordingly.',
+  }
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Madhapur',
+  description: 'Best NEET Coaching for Madhapur Hyderabad - Trusted by Premium Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-madhapur-hyderabad',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Madhapur', 'Hitec City', 'Durgam Cheruvu', 'Kondapur', 'Gachibowli'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ { __html: JSON.stringify(faqSchema) } }
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ { __html: JSON.stringify(localBusinessSchema) } }
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Zap className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Tech Professionals
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Madhapur</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Hyderabad's CyberTowers & Tech Hub
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Premium NEET coaching for Madhapur, Hitec City, Durgam Cheruvu & nearby areas. Learn from Dr. Shekhar C Singh, AIIMS Alumnus - trusted by tech professionals.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Madhapur%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Zap className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Online</div>
+                <div className="text-sm opacity-80">Tech Platform</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">680+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Madhapur & Nearby Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Hyderabad premium families
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {madhapurAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={ { animationDelay: `${index * 50}ms` } }
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Madhapur Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={ { animationDelay: `${index * 100}ms` } }
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={ { animationDelay: `${index * 100}ms` } }
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Madhapur Students, Crack NEET!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Modern coaching for tech families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Madhapur%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-hyderabad"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Hyderabad NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-gachibowli-hyderabad"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Gachibowli Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-madhapur-hyderabad/page.tsx
+++ b/src/app/neet-coaching-madhapur-hyderabad/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Madhapur'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Madhapur | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Madhapur Hyderabad. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Personalized batches & doubt clearing. Book free demo!',
+  keywords: [
+    'NEET coaching Madhapur',
+    'biology tuition Madhapur',
+    'NEET classes Madhapur Hyderabad',
+    'best NEET tutor Madhapur',
+    'medical entrance coaching Madhapur',
+    'NEET preparation Hyderabad',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Madhapur | 98% Success Rate | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Madhapur Hyderabad. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-madhapur-hyderabad`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Madhapur | 98% Success Rate',
+    description:
+      'Join #1 NEET coaching in Madhapur Hyderabad. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-madhapur-hyderabad`,
+  },
+}
+
+export default function NEETCoachingMadhapurPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Madhapur"
+        slug="neet-coaching-madhapur-hyderabad"
+        pageTitle="Best NEET Coaching in Madhapur"
+        pageDescription="Join #1 NEET coaching in Madhapur Hyderabad. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-mylapore-chennai/PageContent.tsx
+++ b/src/app/neet-coaching-mylapore-chennai/PageContent.tsx
@@ -1,0 +1,402 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Crown,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const mylaporeAreas = [
+{ name: 'Mylapore', distance: '16 km', landmark: 'Ultra-Premium' },
+  { name: 'Kapaleeshwarar Temple', distance: '15 km', landmark: 'Heritage Area' },
+  { name: 'Alwarpet', distance: '14 km', landmark: 'Upmarket' },
+  { name: 'Teynampet', distance: '15 km', landmark: 'Residential' },
+  { name: 'Nageswara Rao Park', distance: '17 km', landmark: 'Premium Enclave' },
+  { name: 'Santhome', distance: '18 km', landmark: 'Heritage Zone' },
+  { name: 'Tidel Park', distance: '19 km', landmark: 'IT Zone' },
+  { name: 'Shilp Gram', distance: '20 km', landmark: 'Mixed Use' }
+]
+
+const whyChooseUs = [
+
+]
+
+const faqs = [
+{
+    question: 'Why do Mylapore medical families choose our coaching?',
+    answer:
+      'Mylapore is traditional, wealth-conscious, medical family stronghold. Our coaching respects these values while using modern pedagogy. Many medical professionals and families trust our AIIMS faculty coaching.',
+  },
+  {
+    question: 'How does your coaching respect Mylapore heritage values?',
+    answer:
+      'We combine modern teaching with traditional values of hard work, ethics, and family involvement. Mylapore families appreciate this balance - modern methods with respect for their traditions.',
+  },
+  {
+    question: 'What schools do Mylapore students attend?',
+    answer:
+      'We have students from Cathedral School, Chettinad Vidyashram, Padma Seshadri Bala Bhavan, and heritage institutions. Mylapore families choose premium, traditional schools.',
+  },
+  {
+    question: 'How do you support medical family aspirations?',
+    answer:
+      'Many students come from medical families. We understand their aspirations, family expectations, and competitive pressure. Personalized mentoring helps students achieve family legacy in medicine.',
+  }
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Mylapore',
+  description: 'Best NEET Coaching for Mylapore Chennai - Trusted by Premium Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-mylapore-chennai',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Mylapore', 'Kapaleeshwarar Temple', 'Alwarpet', 'Teynampet', 'Nageswara Rao Park'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ { __html: JSON.stringify(faqSchema) } }
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ { __html: JSON.stringify(localBusinessSchema) } }
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Crown className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Wealthy Medical Families
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Mylapore</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Chennai's Ultra-Conservative Wealth Center
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Premium NEET coaching for Mylapore, Kapaleeshwarar Temple area & nearby heritage families. Learn from Dr. Shekhar C Singh, AIIMS Alumnus - trusted by medical families.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Mylapore%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Crown className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Premium</div>
+                <div className="text-sm opacity-80">Heritage</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">680+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Mylapore & Nearby Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Chennai premium families
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {mylaporeAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={ { animationDelay: `${index * 50}ms` } }
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Mylapore Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={ { animationDelay: `${index * 100}ms` } }
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={ { animationDelay: `${index * 100}ms` } }
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Mylapore Students, Excel in NEET!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium coaching for conservative wealth
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Mylapore%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-chennai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Chennai NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-velachery-chennai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Velachery Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-mylapore-chennai/page.tsx
+++ b/src/app/neet-coaching-mylapore-chennai/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Mylapore'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Mylapore | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Mylapore Chennai. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Personalized batches & doubt clearing. Book free demo!',
+  keywords: [
+    'NEET coaching Mylapore',
+    'biology tuition Mylapore',
+    'NEET classes Mylapore Chennai',
+    'best NEET tutor Mylapore',
+    'medical entrance coaching Mylapore',
+    'NEET preparation Chennai',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Mylapore | 98% Success Rate | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Mylapore Chennai. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-mylapore-chennai`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Mylapore | 98% Success Rate',
+    description:
+      'Join #1 NEET coaching in Mylapore Chennai. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-mylapore-chennai`,
+  },
+}
+
+export default function NEETCoachingMylaporePage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Mylapore"
+        slug="neet-coaching-mylapore-chennai"
+        pageTitle="Best NEET Coaching in Mylapore"
+        pageDescription="Join #1 NEET coaching in Mylapore Chennai. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-navi-mumbai/PageContent.tsx
+++ b/src/app/neet-coaching-navi-mumbai/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Gem,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const naviMumbaiAreas = [
+  { name: 'Kharghar', distance: '25 km', landmark: 'Premium Planned City' },
+  { name: 'Vashi', distance: '24 km', landmark: 'CBD Area' },
+  { name: 'Belapur', distance: '26 km', landmark: 'Coastal Area' },
+  { name: 'Palm Beach Road', distance: '27 km', landmark: 'Upscale Waterfront' },
+  { name: 'CBD Belapur', distance: '26 km', landmark: 'Commercial District' },
+  { name: 'Seawoods', distance: '25 km', landmark: 'Premium Locality' },
+  { name: 'Ghansoli', distance: '23 km', landmark: 'Industrial Area' },
+  { name: 'Airoli', distance: '22 km', landmark: 'Residential Hub' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Gem,
+    title: 'Planned City Expert',
+    description:
+      'Navi Mumbai is India\'s most planned city with premium gated communities. We specialize in coaching for residents of Kharghar, Palm Beach Road, and premium Belapur.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Proven track record with students from elite institutions across Navi Mumbai and satellite areas.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'AIIMS Faculty',
+    description:
+      'Dr. Shekhar C Singh, AIIMS Alumnus with 15+ years experience coaching high-achievers from planned communities.',
+  },
+  {
+    icon: Star,
+    title: 'Top Results',
+    description:
+      'Navi Mumbai students scored 690+ in NEET with multiple AIIMS and top medical college admissions.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Do you have a coaching center in Navi Mumbai?',
+    answer:
+      'Our main center is in Greater Noida. For Navi Mumbai residents, we offer premium live online NEET classes with personalized attention. Many planned community residents prefer online coaching for convenience and safety. Our comprehensive material and recorded lectures ensure uninterrupted preparation.',
+  },
+  {
+    question: 'How do you understand Navi Mumbai planned community needs?',
+    answer:
+      'Navi Mumbai represents organized urban planning with premium communities. We value structure and excellence. Our coaching offers fixed schedules, organized curriculum, detailed progress reports, and result-oriented teaching matching the planned community ethos.',
+  },
+  {
+    question: 'Which schools do your Navi Mumbai students attend?',
+    answer:
+      'We have students from Cathedral School, Bombay Scottish, Jamnabai Narsee, and elite institutions across Navi Mumbai. These academically excellent schools align perfectly with our rigorous NEET preparation.',
+  },
+  {
+    question: 'Is NEET coaching suitable for professionals in Navi Mumbai?',
+    answer:
+      'Absolutely! Many Navi Mumbai professionals have demanding work. Our flexible online platform accommodates work schedules. Live classes can be attended during free hours and recorded sessions provide continuity. Progress tracking helps parents stay informed.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Navi Mumbai',
+  description: 'Best NEET Coaching for Navi Mumbai - Premium planned city coaching',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-navi-mumbai',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Navi Mumbai', 'Kharghar', 'Vashi', 'Belapur', 'Palm Beach Road'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Gem className="w-5 h-5 mr-2 text-yellow-400" />
+              Planned City Coaching | AIIMS Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Navi Mumbai</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium Biology Coaching for India&apos;s Most Planned Metropolitan City
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Exclusive NEET coaching for Navi Mumbai, Kharghar, Vashi, and Belapur. Learn from{' '}
+              <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by Navi Mumbai&apos;s
+              premium families.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Navi%20Mumbai%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Gem className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Planned</div>
+                <div className="text-sm opacity-80">City Focus</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">690+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Navi Mumbai & Extended Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for planned city premium communities
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {naviMumbaiAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Navi Mumbai Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Navi Mumbai Students, Excel in NEET!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium NEET coaching for India&apos;s planned city residents
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Navi%20Mumbai%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-mumbai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Mumbai NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-lodha-mumbai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Lodha Premium Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-navi-mumbai/page.tsx
+++ b/src/app/neet-coaching-navi-mumbai/page.tsx
@@ -1,0 +1,69 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Navi Mumbai'
+const city = 'Metro Area'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: `${locality}`,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Navi Mumbai | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Navi Mumbai. Expert AIIMS faculty, 98% success rate. Kharghar, Vashi, Belapur, Palm Beach Road. Premium online coaching. Book free demo!',
+  keywords: [
+    'NEET coaching Navi Mumbai',
+    'biology tuition Kharghar',
+    'NEET classes Vashi',
+    'best NEET tutor Belapur',
+    'medical entrance Palm Beach Road',
+    'NEET preparation Navi Mumbai',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Navi Mumbai | 98% Success Rate | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Navi Mumbai. Expert AIIMS faculty, 98% success rate. Premium coaching for planned city. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-navi-mumbai`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Navi Mumbai | 98% Success Rate',
+    description:
+      'Join #1 NEET coaching in Navi Mumbai. Expert AIIMS faculty. Premium planned city coaching. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-navi-mumbai`,
+  },
+}
+
+export default function NEETCoachingNaviMumbaiPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Navi Mumbai"
+        slug="neet-coaching-navi-mumbai"
+        pageTitle="Best NEET Coaching in Navi Mumbai"
+        pageDescription="Join #1 NEET coaching in Navi Mumbai. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-new-town-kolkata/PageContent.tsx
+++ b/src/app/neet-coaching-new-town-kolkata/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Shield,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const newTownAreas = [
+  { name: 'New Town Rajarhat', distance: '0 km', landmark: 'IT Hub Center' },
+  { name: 'Eco Park', distance: '2 km', landmark: 'Entertainment Zone' },
+  { name: 'Action Area', distance: '1 km', landmark: 'Corporate Complex' },
+  { name: 'AJC Bose Road', distance: '4 km', landmark: 'East Kolkata Link' },
+  { name: 'New Town Extension', distance: '3 km', landmark: 'Residential Area' },
+  { name: 'Kolkata IT Hub', distance: '5 km', landmark: 'Business District' },
+  { name: 'FD Block', distance: '6 km', landmark: 'New Town Zone' },
+  { name: 'Survey Park', distance: '7 km', landmark: 'Greenfield Area' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Building,
+    title: 'New Town Eco Park IT Families Trust Us',
+    description:
+      'Top choice for New Town Rajarhat professionals working in IT and corporate sectors. Trusted by Eco Park families seeking premium NEET coaching with modern infrastructure.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Successful coaching of students from IIFC, Caliber School, Patha Bhavan, and other premium institutions serving New Town families.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'Modern Medical Faculty',
+    description:
+      'Expert NEET biology coaching by experienced medical professionals with 15+ years teaching background serving New Town\'s dynamic families.',
+  },
+  {
+    icon: Star,
+    title: 'Top NEET Rankings',
+    description:
+      'New Town students consistently achieve 680+ NEET scores and gain admission to AIIMS, Maulana Azad, and CMC medical colleges.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Why is your NEET coaching perfect for New Town families?',
+    answer:
+      'New Town families value modern amenities, quality education, and results. We offer premium online NEET coaching with advanced digital infrastructure, real-time doubt clearing, and personalized guidance. Our coaching aligns with the forward-thinking nature of New Town residents.',
+  },
+  {
+    question: 'Do you have a center in New Town Rajarhat?',
+    answer:
+      'Our NEET coaching is delivered through premium online live classes accessible from New Town. This flexibility is ideal for busy professional families at Eco Park. We provide recorded lectures, comprehensive material, and personalized attention to each student.',
+  },
+  {
+    question: 'Which schools do your New Town students come from?',
+    answer:
+      'We coach students from IIFC School, Caliber School, Patha Bhavan, Heritage School, and other premium institutions. Many come from IT professional families in New Town Rajarhat and Eco Park.',
+  },
+  {
+    question: 'Can I balance school with your NEET coaching?',
+    answer:
+      'Absolutely! Our flexible schedule is designed for students balancing school academics with competitive exam preparation. We offer evening batches, weekend sessions, and recorded lectures so New Town students can study at their convenience.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching New Town',
+  description: 'Best NEET Coaching for New Town Rajarhat Kolkata - Trusted by IT Hub Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-new-town-kolkata',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Kolkata',
+    addressRegion: 'West Bengal',
+    addressCountry: 'IN',
+  },
+  areaServed: ['New Town', 'Rajarhat', 'Eco Park', 'Action Area', 'East Kolkata'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Building className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by New Town Professionals | Modern Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">New Town Rajarhat</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Modern NEET Coaching for Kolkata's Newest Premier Community
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Expert NEET coaching for New Town Rajarhat, Eco Park, and Action Area. Learn from
+              experienced medical faculty trusted by <strong>IT professionals and corporate families</strong>. Premium
+              online classes with modern infrastructure and recorded lectures.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20New%20Town%20Rajarhat%20Kolkata%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Modern</div>
+                <div className="text-sm opacity-80">Infrastructure</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Star className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">680+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              New Town & Nearby IT Hub Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for East Kolkata's modern business district
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {newTownAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why New Town Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              New Town Students, Excel in NEET!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Modern NEET coaching matching the ambition of New Town's dynamic families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20New%20Town%20Rajarhat%20Kolkata%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-kolkata"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Kolkata NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-salt-lake-kolkata"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Salt Lake Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-new-town-kolkata/page.tsx
+++ b/src/app/neet-coaching-new-town-kolkata/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'New Town Rajarhat'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in New Town Rajarhat Kolkata | IT Hub | Cerebrum',
+  description:
+    'Join #1 NEET coaching in New Town Rajarhat, Kolkata. Expert faculty, proven 98% success rate, 695/720 top score. Premium coaching for Eco Park & Action Area families. Book free demo!',
+  keywords: [
+    'NEET coaching New Town',
+    'biology tuition Rajarhat Kolkata',
+    'NEET classes New Town Rajarhat',
+    'best NEET tutor Eco Park',
+    'medical entrance Action Area',
+    'NEET preparation New Town Kolkata',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in New Town Rajarhat Kolkata | IT Hub | Cerebrum',
+    description:
+      'Join #1 NEET coaching in New Town Rajarhat, Kolkata. Expert faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-new-town-kolkata`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in New Town Rajarhat Kolkata | IT Hub',
+    description:
+      'Join #1 NEET coaching in New Town Rajarhat, Kolkata. Expert faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-new-town-kolkata`,
+  },
+}
+
+export default function NEETCoachingNewTownKolkataPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="New Town Rajarhat"
+        slug="neet-coaching-new-town-kolkata"
+        pageTitle="Best NEET Coaching in New Town Rajarhat"
+        pageDescription="Join #1 NEET coaching in New Town Rajarhat, Kolkata. Expert faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-nungambakkam-chennai/PageContent.tsx
+++ b/src/app/neet-coaching-nungambakkam-chennai/PageContent.tsx
@@ -1,0 +1,402 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Building,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const nungambakkamAreas = [
+{ name: 'Nungambakkam', distance: '17 km', landmark: 'Premium Residential' },
+  { name: 'Teynampet', distance: '16 km', landmark: 'Business District' },
+  { name: 'Chetpet', distance: '15 km', landmark: 'Residential' },
+  { name: 'Alwarpet', distance: '14 km', landmark: 'Upmarket Area' },
+  { name: 'Mylapore', distance: '18 km', landmark: 'Heritage Zone' },
+  { name: 'Abiramapuram', distance: '19 km', landmark: 'Premium Area' },
+  { name: 'Santhome', distance: '20 km', landmark: 'Heritage Enclave' },
+  { name: 'Cathedral Road', distance: '16 km', landmark: 'Premium Address' }
+]
+
+const whyChooseUs = [
+
+]
+
+const faqs = [
+{
+    question: 'Why Nungambakkam families choose premium NEET coaching?',
+    answer:
+      'Nungambakkam is Chennai's most prestigious residential area. Families here expect white-glove service, world-class faculty, and results. Our premium coaching with AIIMS faculty meets these expectations.',
+  },
+  {
+    question: 'How do you provide premium service?',
+    answer:
+      'Personalized mentoring, small batches, dedicated doubt clearing, regular progress reports, and exclusive family consultations. Premium families receive premium service.',
+  },
+  {
+    question: 'What schools do Nungambakkam students attend?',
+    answer:
+      'We have students from Chennai's most prestigious schools - Cathedral, Chettinad, PSBB, Padma Seshadri. Nungambakkam families choose the best schools and coaching.',
+  },
+  {
+    question: 'How do you support Nungambakkam's prominent families?',
+    answer:
+      'Many Nungambakkam families are business leaders and prominent professionals. We understand their high expectations, provide exclusive service, and maintain confidentiality that they value.',
+  }
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Nungambakkam',
+  description: 'Best NEET Coaching for Nungambakkam Chennai - Trusted by Premium Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-nungambakkam-chennai',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Nungambakkam', 'Teynampet', 'Chetpet', 'Alwarpet', 'Mylapore'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ { __html: JSON.stringify(faqSchema) } }
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ { __html: JSON.stringify(localBusinessSchema) } }
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Building className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Business Families
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Nungambakkam</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium Residential & Business District
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Premium NEET coaching for Nungambakkam, business families & nearby premium areas. Learn from Dr. Shekhar C Singh, AIIMS Alumnus - trusted by Chennai's prominent families.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Nungambakkam%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Premium</div>
+                <div className="text-sm opacity-80">Families</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">680+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Nungambakkam & Nearby Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Chennai premium families
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {nungambakkamAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={ { animationDelay: `${index * 50}ms` } }
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Nungambakkam Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={ { animationDelay: `${index * 100}ms` } }
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={ { animationDelay: `${index * 100}ms` } }
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Nungambakkam Students, Crack NEET!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium coaching for Chennai's elite
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Nungambakkam%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-chennai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Chennai NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-mylapore-chennai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Mylapore Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-nungambakkam-chennai/page.tsx
+++ b/src/app/neet-coaching-nungambakkam-chennai/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Nungambakkam'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Nungambakkam | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Nungambakkam Chennai. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Personalized batches & doubt clearing. Book free demo!',
+  keywords: [
+    'NEET coaching Nungambakkam',
+    'biology tuition Nungambakkam',
+    'NEET classes Nungambakkam Chennai',
+    'best NEET tutor Nungambakkam',
+    'medical entrance coaching Nungambakkam',
+    'NEET preparation Chennai',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Nungambakkam | 98% Success Rate | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Nungambakkam Chennai. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-nungambakkam-chennai`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Nungambakkam | 98% Success Rate',
+    description:
+      'Join #1 NEET coaching in Nungambakkam Chennai. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-nungambakkam-chennai`,
+  },
+}
+
+export default function NEETCoachingNungambakkamPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Nungambakkam"
+        slug="neet-coaching-nungambakkam-chennai"
+        pageTitle="Best NEET Coaching in Nungambakkam"
+        pageDescription="Join #1 NEET coaching in Nungambakkam Chennai. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-park-street-kolkata/PageContent.tsx
+++ b/src/app/neet-coaching-park-street-kolkata/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Shield,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const parkStreetAreas = [
+  { name: 'Park Street', distance: '0 km', landmark: 'Central Kolkata Hub' },
+  { name: 'Chowringhee', distance: '1 km', landmark: 'Heritage Area' },
+  { name: 'Esplanade', distance: '2 km', landmark: 'Central Business District' },
+  { name: 'Mullick Ghat', distance: '3 km', landmark: 'Historic District' },
+  { name: 'Shyambazar', distance: '4 km', landmark: 'North Kolkata' },
+  { name: 'Belgachia', distance: '5 km', landmark: 'Residential Area' },
+  { name: 'Tala', distance: '6 km', landmark: 'West Kolkata' },
+  { name: 'Sovabazar', distance: '7 km', landmark: 'Traditional Area' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Building,
+    title: 'Central Kolkata Professionals Trust Us',
+    description:
+      'Top choice for Park Street business families and central Kolkata professionals. Trusted by corporate executives seeking premium NEET coaching for their children.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Proven success with students from Cathedral School, St. Xavier\'s, Bhawanipur Education Society, and top central Kolkata institutions.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'Expert Medical Faculty',
+    description:
+      'NEET biology coaching by experienced medical professionals with 15+ years expertise teaching students from central Kolkata premium families.',
+  },
+  {
+    icon: Star,
+    title: 'Consistent Top Results',
+    description:
+      'Park Street students achieve 685+ NEET scores and secure AIIMS, Maulana Azad, and other prestigious medical college admissions.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Why is your NEET coaching popular in central Kolkata?',
+    answer:
+      'Park Street and central Kolkata professionals value quality, accessibility, and results. We offer premium online NEET coaching with personalized attention, comprehensive study material, and proven 98% success rate. Our central location makes it accessible to busy families.',
+  },
+  {
+    question: 'Do you have classes near Park Street?',
+    answer:
+      'Our NEET coaching is delivered through premium online live classes accessible from anywhere. This provides flexibility for central Kolkata professionals. We offer recorded lectures, regular tests, and personalized doubt clearing sessions.',
+  },
+  {
+    question: 'Which schools do your Park Street students come from?',
+    answer:
+      'We coach students from Cathedral School, St. Xavier\'s Collegiate School, Bhawanipur Education Society, South Point School, and other premier central Kolkata educational institutions.',
+  },
+  {
+    question: 'How long is the NEET coaching program?',
+    answer:
+      'Our NEET coaching program spans the critical 2-year period before the NEET exam. We offer flexible batches - you can join at any point and get personalized guidance. Weekend and intensive batches are available for Park Street students.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Park Street',
+  description: 'Best NEET Coaching for Park Street Kolkata - Premium Coaching for Central Kolkata Professionals',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-park-street-kolkata',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Kolkata',
+    addressRegion: 'West Bengal',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Park Street', 'Chowringhee', 'Esplanade', 'Central Kolkata'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Building className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Central Kolkata Professionals | Premium Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Park Street Kolkata</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium NEET Coaching for Central Kolkata's Vibrant Community
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Expert NEET coaching for Park Street, Chowringhee, and central Kolkata areas. Learn from
+              accomplished medical faculty trusted by <strong>business professionals and corporate families</strong>. Premium
+              online classes with recorded lectures and proven 685+ NEET results.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Park%20Street%20Kolkata%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Central</div>
+                <div className="text-sm opacity-80">Kolkata Base</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Star className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">685+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Park Street & Central Kolkata Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for central Kolkata's premier communities
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {parkStreetAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Park Street Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Park Street Students, Conquer NEET Together!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium NEET coaching connecting central Kolkata's most ambitious students
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Park%20Street%20Kolkata%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-kolkata"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Kolkata NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-salt-lake-kolkata"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Salt Lake Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-park-street-kolkata/page.tsx
+++ b/src/app/neet-coaching-park-street-kolkata/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Park Street'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Park Street Kolkata | Central Premium | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Park Street, Kolkata. Expert faculty, proven 98% success rate, 695/720 top score. Premium coaching for central Kolkata families. Book free demo!',
+  keywords: [
+    'NEET coaching Park Street',
+    'biology tuition Park Street Kolkata',
+    'NEET classes Park Street',
+    'best NEET tutor central Kolkata',
+    'medical entrance Park Street',
+    'NEET preparation premium central Kolkata',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Park Street Kolkata | Central Premium | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Park Street, Kolkata. Expert faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-park-street-kolkata`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Park Street Kolkata | Premium',
+    description:
+      'Join #1 NEET coaching in Park Street, Kolkata. Expert faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-park-street-kolkata`,
+  },
+}
+
+export default function NEETCoachingParkStreetKolkataPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Park Street"
+        slug="neet-coaching-park-street-kolkata"
+        pageTitle="Best NEET Coaching in Park Street"
+        pageDescription="Join #1 NEET coaching in Park Street, Kolkata. Expert faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-prahlad-nagar-ahmedabad/PageContent.tsx
+++ b/src/app/neet-coaching-prahlad-nagar-ahmedabad/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Shield,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const prahladNagarAreas = [
+  { name: 'Prahlad Nagar', distance: '0 km', landmark: 'Corporate Hub' },
+  { name: 'Satellite', distance: '2 km', landmark: 'Premium Area' },
+  { name: 'Thaltej', distance: '3 km', landmark: 'IT Park' },
+  { name: 'Bodakdev', distance: '4 km', landmark: 'Premium Residential' },
+  { name: 'Vastrapur', distance: '5 km', landmark: 'Upscale Zone' },
+  { name: 'Akshar Marg', distance: '2 km', landmark: 'Residential Area' },
+  { name: 'Navrangpura', distance: '6 km', landmark: 'Central Ahmedabad' },
+  { name: 'Shahibaug', distance: '7 km', landmark: 'Business District' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Building,
+    title: 'Prahlad Nagar Corporate Families Trust Us',
+    description:
+      'Top choice for Prahlad Nagar professionals and executives. Trusted by corporate families seeking premium NEET coaching with proven results.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Successful coaching of students from Udgam, Ahmedabad International School, GD Goenka, and top Ahmedabad institutions.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'Expert Medical Faculty',
+    description:
+      'NEET biology coaching by experienced medical professionals with 15+ years expertise teaching Prahlad Nagar families.',
+  },
+  {
+    icon: Star,
+    title: 'Top NEET Results',
+    description:
+      'Prahlad Nagar students achieve 685+ NEET scores and secure AIIMS, CMC Vellore, and leading medical college seats.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Why should I choose your NEET coaching in Prahlad Nagar?',
+    answer:
+      'Prahlad Nagar families value quality education and professional excellence. We provide premium online NEET coaching with expert faculty, structured approach, and proven success. Our coaching aligns with the high standards of corporate families.',
+  },
+  {
+    question: 'Do you have an office in Prahlad Nagar?',
+    answer:
+      'Our NEET coaching is delivered through premium online live classes. This flexibility suits busy corporate families in Prahlad Nagar. We provide recorded lectures, comprehensive material, and regular assessments.',
+  },
+  {
+    question: 'Which schools do your students come from?',
+    answer:
+      'We coach students from Udgam School, Ahmedabad International School, GD Goenka, Vibrant Academy, and other premier Ahmedabad institutions.',
+  },
+  {
+    question: 'How flexible is your NEET coaching schedule?',
+    answer:
+      'We offer morning, evening, and weekend batches. Students can choose schedules that suit their school and family commitments. Live classes have recorded backup options.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Prahlad Nagar',
+  description: 'Best NEET Coaching for Prahlad Nagar Ahmedabad - Premium Coaching for Corporate Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-prahlad-nagar-ahmedabad',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Ahmedabad',
+    addressRegion: 'Gujarat',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Prahlad Nagar', 'Satellite', 'Thaltej', 'Bodakdev', 'Ahmedabad'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Building className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Prahlad Nagar Professionals | Expert Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Prahlad Nagar Ahmedabad</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium NEET Coaching for Corporate Hub Excellence
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Expert NEET coaching for Prahlad Nagar, Satellite area, and surrounding corporate zones. Learn from
+              accomplished medical faculty trusted by <strong>corporate executives and professional families</strong>. Premium
+              online classes with proven 685+ NEET results.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Prahlad%20Nagar%20Ahmedabad%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Corporate</div>
+                <div className="text-sm opacity-80">Hub Experts</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Star className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">685+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Prahlad Nagar & Premium Corporate Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Ahmedabad's corporate hubs and premium zones
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {prahladNagarAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Prahlad Nagar Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Prahlad Nagar Students, Achieve NEET Success!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium NEET coaching for Prahlad Nagar's ambitious corporate families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Prahlad%20Nagar%20Ahmedabad%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-ahmedabad"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Ahmedabad NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-sg-highway-ahmedabad"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              SG Highway Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-prahlad-nagar-ahmedabad/page.tsx
+++ b/src/app/neet-coaching-prahlad-nagar-ahmedabad/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Prahlad Nagar'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Prahlad Nagar Ahmedabad | Corporate Hub | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Prahlad Nagar, Ahmedabad. Expert faculty, proven 98% success rate, 695/720 top score. Premium coaching for Satellite area families. Book free demo!',
+  keywords: [
+    'NEET coaching Prahlad Nagar',
+    'biology tuition Prahlad Nagar Ahmedabad',
+    'NEET classes Prahlad Nagar',
+    'best NEET tutor Satellite area',
+    'medical entrance Prahlad Nagar',
+    'NEET preparation corporate hub',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Prahlad Nagar Ahmedabad | Corporate Hub | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Prahlad Nagar, Ahmedabad. Expert faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-prahlad-nagar-ahmedabad`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Prahlad Nagar Ahmedabad | Corporate Hub',
+    description:
+      'Join #1 NEET coaching in Prahlad Nagar, Ahmedabad. Expert faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-prahlad-nagar-ahmedabad`,
+  },
+}
+
+export default function NEETCoachingPrahladNagarAhmedabadPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Prahlad Nagar"
+        slug="neet-coaching-prahlad-nagar-ahmedabad"
+        pageTitle="Best NEET Coaching in Prahlad Nagar"
+        pageDescription="Join #1 NEET coaching in Prahlad Nagar, Ahmedabad. Expert faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-salt-lake-kolkata/PageContent.tsx
+++ b/src/app/neet-coaching-salt-lake-kolkata/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Shield,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const saltLakeAreas = [
+  { name: 'Salt Lake Sector V', distance: '0 km', landmark: 'IT Hub Core' },
+  { name: 'Salt Lake Sector IV', distance: '2 km', landmark: 'Residential Complex' },
+  { name: 'Salt Lake Sector III', distance: '3 km', landmark: 'Golf Club Adjacent' },
+  { name: 'Salt Lake Sector I', distance: '4 km', landmark: 'Nicco Park' },
+  { name: 'Rajarhat', distance: '5 km', landmark: 'New Town Extension' },
+  { name: 'Dakshineswar', distance: '7 km', landmark: 'North Kolkata' },
+  { name: 'Dum Dum', distance: '8 km', landmark: 'Airport Area' },
+  { name: 'Barrackpore', distance: '12 km', landmark: 'Cantonment Area' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Building,
+    title: 'Sector V IT Families Trust Us',
+    description:
+      'Top choice for IT professionals and business families living in Salt Lake gated communities. Proven track record with Sector V student success.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Successful coaching of students from IIFC, Caliber School, Patha Bhavan, and premium Kolkata schools in Salt Lake area.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'Expert Biology Faculty',
+    description:
+      'Specialized NEET biology coaching by medical professionals with 15+ years experience teaching aspirants from elite backgrounds.',
+  },
+  {
+    icon: Star,
+    title: 'Top NEET Results',
+    description:
+      'Salt Lake students consistently score 680+ in NEET and secure seats in AIIMS, Maulana Azad, and CMC Vellore.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Do you have an offline center in Salt Lake, Kolkata?',
+    answer:
+      'Our coaching is delivered through premium online live classes, ideal for Sector V families. Many IT professionals prefer online delivery for flexibility. Our comprehensive material and recorded lectures ensure quality learning. Students can attend live sessions from home at their convenience.',
+  },
+  {
+    question: 'Why do Salt Lake families choose your NEET coaching?',
+    answer:
+      'Salt Lake families value quality, results, and modern teaching methods. We provide structured NEET preparation with recorded lectures, regular tests, and personalized doubt clearing. Our success rate of 98% resonates with quality-conscious families in premium Sector V communities.',
+  },
+  {
+    question: 'What schools do your Salt Lake students come from?',
+    answer:
+      'We coach students from IIFC School, Caliber School, Patha Bhavan, Heritage School, La Martiniere Girls, and other premium institutions. Many come from IT professional families seeking excellence in medical entrance preparation.',
+  },
+  {
+    question: 'Can I join NEET coaching while working on other entrance exams?',
+    answer:
+      'Absolutely! Our flexible schedule allows students to prepare for NEET alongside other competitive exams like KVPY, JEE, and state medical entrance exams. Many Salt Lake students balance multiple competitive exam preparations with our guidance.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Salt Lake',
+  description: 'Best NEET Coaching for Salt Lake Kolkata - Trusted by IT Families in Sector V',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-salt-lake-kolkata',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Kolkata',
+    addressRegion: 'West Bengal',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Salt Lake', 'Sector V', 'Rajarhat', 'New Town', 'North Kolkata'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Building className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Sector V IT Families | Expert Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Salt Lake Kolkata</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium Biology Coaching for Gated Community Elite
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Expert NEET coaching for Salt Lake Sector V, Rajarhat & nearby areas. Learn from
+              experienced medical faculty trusted by <strong>IT professionals and business families</strong>. Premium
+              online classes with recorded lectures and regular assessments.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Salt%20Lake%20Kolkata%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Sector V</div>
+                <div className="text-sm opacity-80">IT Hub Specialists</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Star className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">680+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Salt Lake & Nearby Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Kolkata's premium residential zones
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {saltLakeAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Salt Lake Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Salt Lake Families, Ace NEET with Excellence!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium online NEET coaching matching the high standards of Sector V professionals
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Salt%20Lake%20Kolkata%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-kolkata"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Kolkata NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-ballygunge-kolkata"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Ballygunge Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-salt-lake-kolkata/page.tsx
+++ b/src/app/neet-coaching-salt-lake-kolkata/page.tsx
@@ -1,0 +1,69 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Salt Lake'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Salt Lake Kolkata | Premium Coaching | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Salt Lake, Kolkata. Expert faculty, proven 98% success rate, 695/720 top score. Perfect for Sector V IT families. Personalized batches & doubt clearing. Book free demo!',
+  keywords: [
+    'NEET coaching Salt Lake',
+    'biology tuition Salt Lake Kolkata',
+    'NEET classes Salt Lake',
+    'best NEET tutor Salt Lake',
+    'medical entrance Sector V',
+    'NEET preparation Kolkata gated community',
+    'Salt Lake Sector V NEET coaching',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Salt Lake Kolkata | Premium Coaching | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Salt Lake, Kolkata. Expert faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-salt-lake-kolkata`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Salt Lake Kolkata | Premium Coaching',
+    description:
+      'Join #1 NEET coaching in Salt Lake, Kolkata. Expert faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-salt-lake-kolkata`,
+  },
+}
+
+export default function NEETCoachingSaltLakeKolkataPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Salt Lake"
+        slug="neet-coaching-salt-lake-kolkata"
+        pageTitle="Best NEET Coaching in Salt Lake"
+        pageDescription="Join #1 NEET coaching in Salt Lake, Kolkata. Expert faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-sarjapur-road-bangalore/PageContent.tsx
+++ b/src/app/neet-coaching-sarjapur-road-bangalore/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Zap,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const sarjapurAreas = [
+  { name: 'Sarjapur Road', distance: '12 km', landmark: 'IT Executive Zone' },
+  { name: 'Marathahalli', distance: '8 km', landmark: 'Near Tech Parks' },
+  { name: 'Bellandur', distance: '15 km', landmark: 'Premium Residential' },
+  { name: 'Whitefield', distance: '18 km', landmark: 'IT Hub' },
+  { name: 'Varthur', distance: '14 km', landmark: 'Tech Corridor' },
+  { name: 'Harambu', distance: '10 km', landmark: 'Emerging IT Zone' },
+  { name: 'Hoodi', distance: '11 km', landmark: 'Residential Area' },
+  { name: 'Kadubeesanahalli', distance: '13 km', landmark: 'Gated Communities' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Zap,
+    title: 'Premium IT Executive Families',
+    description:
+      'Trusted by IT professionals and executive families in Sarjapur Road gated communities.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Proven track record with students from premium schools - DPS Sarjapur, Delhi World School, and international curricula backgrounds.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'AIIMS Faculty & Online Excellence',
+    description:
+      'Dr. Shekhar C Singh, AIIMS Alumnus with 15+ years experience. Flexible online classes perfect for executive families.',
+  },
+  {
+    icon: Star,
+    title: 'Top Results & Premium Support',
+    description:
+      'Students consistently score 680+, with personalized mentoring and 24/7 doubt resolution for busy professional families.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Is there a coaching center in Sarjapur Road Bangalore?',
+    answer:
+      'Our main center is in Greater Noida. For Sarjapur Road IT professionals and families, we offer premium live online NEET classes with recorded lectures. This flexible format suits busy executive families who value convenience without compromising quality. Your child gets world-class coaching from AIIMS faculty right from home.',
+  },
+  {
+    question: 'Why is online coaching better for Sarjapur Road families?',
+    answer:
+      'Executive families in Sarjapur Road appreciate flexibility. Online coaching eliminates commute time, allows students to learn at their own pace, and ensures consistent quality even during travel or transfers. Parents receive regular progress reports and our premium support system ensures no doubt goes unanswered.',
+  },
+  {
+    question: 'What schools do your Sarjapur Road students come from?',
+    answer:
+      'We have students from DPS Sarjapur, Delhi World School, Inventure Academy, Greenwood High School, and other premium institutions in East Bangalore. Many students also transition from international curricula (CBSE, IB, IGCSE), and we specialize in bridging this gap for NEET preparation.',
+  },
+  {
+    question: 'How do you support IT professionals working in Bangalore tech parks?',
+    answer:
+      'We understand executive family dynamics - parents with demanding schedules. Our platform offers live classes during flexible hours, recorded sessions for revision, recorded doubt clearing, and progress tracking dashboards. Students can study independently while parents monitor advancement through our parent portal.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Sarjapur Road',
+  description: 'Best NEET Coaching for Sarjapur Road Bangalore - Trusted by IT Executive Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-sarjapur-road-bangalore',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Sarjapur Road', 'Marathahalli', 'Bellandur', 'Whitefield', 'Varthur'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Zap className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by IT Executives | AIIMS Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Sarjapur Road</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium Biology Coaching for Bangalore&apos;s IT Executive Zone
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Premium NEET coaching for Sarjapur Road, Marathahalli, Bellandur & nearby areas.
+              Learn from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by IT
+              professionals and executive families.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Sarjapur%20Road%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Zap className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Online</div>
+                <div className="text-sm opacity-80">Classes 24/7</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">680+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Sarjapur Road & Nearby Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for East Bangalore IT professionals and families
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {sarjapurAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Sarjapur Road Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Sarjapur Road Students, Crack NEET Online!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium NEET coaching with flexibility for executive families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Sarjapur%20Road%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-bangalore"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Bangalore NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-electronic-city-bangalore"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Electronic City Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-sarjapur-road-bangalore/page.tsx
+++ b/src/app/neet-coaching-sarjapur-road-bangalore/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Sarjapur Road'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Sarjapur Road | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Sarjapur Road Bangalore. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Personalized batches & doubt clearing. Book free demo!',
+  keywords: [
+    'NEET coaching Sarjapur Road',
+    'biology tuition Sarjapur Road',
+    'NEET classes Sarjapur Road Bangalore',
+    'best NEET tutor Sarjapur Road',
+    'medical entrance coaching Sarjapur Road',
+    'NEET preparation East Bangalore',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Sarjapur Road | 98% Success Rate | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Sarjapur Road Bangalore. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-sarjapur-road-bangalore`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Sarjapur Road | 98% Success Rate',
+    description:
+      'Join #1 NEET coaching in Sarjapur Road Bangalore. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-sarjapur-road-bangalore`,
+  },
+}
+
+export default function NEETCoachingSarjapurRoadPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Sarjapur Road"
+        slug="neet-coaching-sarjapur-road-bangalore"
+        pageTitle="Best NEET Coaching in Sarjapur Road"
+        pageDescription="Join #1 NEET coaching in Sarjapur Road Bangalore. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-satellite-ahmedabad/PageContent.tsx
+++ b/src/app/neet-coaching-satellite-ahmedabad/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Shield,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const satelliteAreas = [
+  { name: 'Satellite', distance: '0 km', landmark: 'Premium Corridor' },
+  { name: 'Drive-In Road', distance: '1 km', landmark: 'Premium Area' },
+  { name: 'Prahlad Nagar', distance: '3 km', landmark: 'Corporate Hub' },
+  { name: 'Bodakdev', distance: '4 km', landmark: 'Premium Residential' },
+  { name: 'Vastrapur', distance: '2 km', landmark: 'Upscale Zone' },
+  { name: 'Thaltej', distance: '5 km', landmark: 'IT Park' },
+  { name: 'Akshar Marg', distance: '3 km', landmark: 'Residential Area' },
+  { name: 'Navrangpura', distance: '6 km', landmark: 'Central Ahmedabad' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Building,
+    title: 'Satellite Drive-In Road Families Trust Us',
+    description:
+      'Top choice for premium Satellite and Drive-In Road families. Trusted by professionals seeking quality NEET coaching with proven results.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Successful coaching of students from Udgam, Ahmedabad International School, GD Goenka, and top Ahmedabad premium institutions.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'Expert Medical Faculty',
+    description:
+      'NEET biology coaching by experienced medical professionals with 15+ years expertise teaching Satellite premium families.',
+  },
+  {
+    icon: Star,
+    title: 'Top Scores & Admissions',
+    description:
+      'Satellite students achieve 685+ NEET scores and secure AIIMS, CMC Vellore, and other prestigious medical college seats.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Why do Satellite families choose your NEET coaching?',
+    answer:
+      'Satellite families value quality, results, and modern teaching methods. We provide premium online NEET coaching with expert faculty, structured curriculum, and proven success rate. Our coaching matches the high standards of Drive-In Road professionals.',
+  },
+  {
+    question: 'Do you have coaching centers in Satellite?',
+    answer:
+      'Our NEET coaching is delivered through premium online live classes. This flexibility suits busy Satellite professionals perfectly. We provide recorded lectures, comprehensive study material, and personalized guidance.',
+  },
+  {
+    question: 'Which schools do your Satellite students come from?',
+    answer:
+      'We coach students from Udgam School, Ahmedabad International School, GD Goenka, Vibrant Academy, and other premier Ahmedabad institutions in Satellite area.',
+  },
+  {
+    question: 'How personalized is your NEET coaching?',
+    answer:
+      'Each student receives personalized attention with customized study plans. We provide regular one-on-one doubt clearing sessions, progress tracking, and targeted support for Satellite students.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Satellite',
+  description: 'Best NEET Coaching for Satellite Ahmedabad - Premium Coaching for Drive-In Road Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-satellite-ahmedabad',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Ahmedabad',
+    addressRegion: 'Gujarat',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Satellite', 'Drive-In Road', 'Prahlad Nagar', 'Bodakdev', 'Ahmedabad'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Building className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Satellite Professionals | Expert Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Satellite Ahmedabad</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium NEET Coaching for Drive-In Road Elite
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Expert NEET coaching for Satellite, Drive-In Road, and premium Ahmedabad zones. Learn from
+              accomplished medical faculty trusted by <strong>professionals and business families</strong>. Premium
+              online classes with proven 685+ NEET results.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Satellite%20Ahmedabad%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Premium</div>
+                <div className="text-sm opacity-80">Corridor</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Star className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">685+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Satellite & Premium Ahmedabad Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Ahmedabad's premium residential corridors
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {satelliteAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Satellite Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Satellite Students, Ace NEET with Excellence!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium NEET coaching for Satellite's finest families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Satellite%20Ahmedabad%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-ahmedabad"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Ahmedabad NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-sg-highway-ahmedabad"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              SG Highway Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-satellite-ahmedabad/page.tsx
+++ b/src/app/neet-coaching-satellite-ahmedabad/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Satellite'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Satellite Ahmedabad | Premium Drive-In Road | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Satellite, Ahmedabad. Expert faculty, proven 98% success rate, 695/720 top score. Premium coaching for Drive-In Road families. Book free demo!',
+  keywords: [
+    'NEET coaching Satellite',
+    'biology tuition Satellite Ahmedabad',
+    'NEET classes Drive-In Road',
+    'best NEET tutor Satellite',
+    'medical entrance Satellite Ahmedabad',
+    'NEET preparation premium residential',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Satellite Ahmedabad | Premium Drive-In Road | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Satellite, Ahmedabad. Expert faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-satellite-ahmedabad`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Satellite Ahmedabad | Premium',
+    description:
+      'Join #1 NEET coaching in Satellite, Ahmedabad. Expert faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-satellite-ahmedabad`,
+  },
+}
+
+export default function NEETCoachingSatelliteAhmedabadPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Satellite"
+        slug="neet-coaching-satellite-ahmedabad"
+        pageTitle="Best NEET Coaching in Satellite"
+        pageDescription="Join #1 NEET coaching in Satellite, Ahmedabad. Expert faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-secunderabad-hyderabad/PageContent.tsx
+++ b/src/app/neet-coaching-secunderabad-hyderabad/PageContent.tsx
@@ -1,0 +1,402 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Shield,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const secunderabadAreas = [
+{ name: 'Secunderabad', distance: '17 km', landmark: 'Cantonment' },
+  { name: 'Bolarum', distance: '16 km', landmark: 'Defence Area' },
+  { name: 'Jeedimetla', distance: '14 km', landmark: 'Residential' },
+  { name: 'Trimulgherry', distance: '15 km', landmark: 'Cantonment' },
+  { name: 'Alwal', distance: '18 km', landmark: 'Residential Zone' },
+  { name: 'Kachiguda', distance: '19 km', landmark: 'Mixed Area' },
+  { name: 'Ameerpet', distance: '16 km', landmark: 'Educational Hub' },
+  { name: 'Nampally', distance: '20 km', landmark: 'Historic Area' }
+]
+
+const whyChooseUs = [
+
+]
+
+const faqs = [
+{
+    question: 'Why defence families prefer our NEET coaching?',
+    answer:
+      'Defence families value discipline, structure, and results. Our coaching mirrors these values - fixed schedules, rigorous testing, clear milestones, and results-oriented approach aligns with defence family expectations.',
+  },
+  {
+    question: 'Do you prepare students for AFMC along with NEET?',
+    answer:
+      'Yes! Many defence families aspire for AFMC admissions. NEET score is fundamental for AFMC. We cover complete NEET syllabus and provide additional AFMC-specific guidance for defence backgrounds.',
+  },
+  {
+    question: 'What schools do Secunderabad defence students attend?',
+    answer:
+      'We have students from Delhi Public School, Army Public Schools, Nalanda, and defence-background institutions. These disciplined environments complement our rigorous preparation.',
+  },
+  {
+    question: 'How do you support military family transfers?',
+    answer:
+      'Defence transfers are frequent. Our online platform ensures learning continuity across postings. Students maintain same faculty, progress, and support system regardless of relocation.',
+  }
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Secunderabad',
+  description: 'Best NEET Coaching for Secunderabad Hyderabad - Trusted by Premium Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-secunderabad-hyderabad',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Secunderabad', 'Bolarum', 'Jeedimetla', 'Trimulgherry', 'Alwal'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ { __html: JSON.stringify(faqSchema) } }
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ { __html: JSON.stringify(localBusinessSchema) } }
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Shield className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Defence Families
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Secunderabad</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Hyderabad's Cantonment Area
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Premium NEET coaching for Secunderabad, Cantonment, defence families & nearby areas. Learn from Dr. Shekhar C Singh, AIIMS Alumnus - trusted by military and defence backgrounds.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Secunderabad%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Shield className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Defence</div>
+                <div className="text-sm opacity-80">Families</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">680+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Secunderabad & Nearby Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Hyderabad premium families
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {secunderabadAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={ { animationDelay: `${index * 50}ms` } }
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Secunderabad Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={ { animationDelay: `${index * 100}ms` } }
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={ { animationDelay: `${index * 100}ms` } }
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Secunderabad Students, Crack NEET!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Disciplined coaching for defence families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Secunderabad%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-hyderabad"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Hyderabad NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-banjara-hills-hyderabad"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Banjara Hills Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-secunderabad-hyderabad/page.tsx
+++ b/src/app/neet-coaching-secunderabad-hyderabad/page.tsx
@@ -1,470 +1,68 @@
-'use client'
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
 
-import { motion } from 'framer-motion'
-import {
-  MapPin,
-  Users,
-  Trophy,
-  Star,
-  Award,
-  BookOpen,
-  Clock,
-  Shield,
-  Video,
-  MessageCircle,
-  Play,
-  ArrowRight,
-  GraduationCap,
-  Building,
-  Phone,
-  Calculator,
-  Target,
-  Sparkles,
-} from 'lucide-react'
-import { Button } from '@/components/ui/Button'
-import Link from 'next/link'
-import { VideoTestimonialsSection } from '@/components/testimonials/VideoTestimonialsSection'
-import { CitySchema } from '@/components/seo/CitySchema'
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Secunderabad'
 
-const WHATSAPP_NUMBER = '918826444334'
-const WHATSAPP_MESSAGE = encodeURIComponent(
-  'Hi! I am interested in NEET coaching in Secunderabad Hyderabad. Please share details.'
-)
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
 
-const localities = [
-  { name: 'Secunderabad', students: '250+', highlight: 'Cantonment Area', priority: 'high' },
-  { name: 'Begumpet', students: '180+', highlight: 'Premium Hub', priority: 'high' },
-  { name: 'Trimulgherry', students: '140+', highlight: 'Defence Colony', priority: 'high' },
-  { name: 'Alwal', students: '120+', highlight: 'Residential', priority: 'medium' },
-  { name: 'Malkajgiri', students: '160+', highlight: 'Growing Fast', priority: 'high' },
-  { name: 'Tarnaka', students: '130+', highlight: 'University Area', priority: 'medium' },
-  { name: 'Marredpally', students: '110+', highlight: 'East Secunderabad', priority: 'medium' },
-  { name: 'Bowenpally', students: '95+', highlight: 'North Zone', priority: 'medium' },
-]
-
-const features = [
-  {
-    icon: Video,
-    title: 'Live Interactive Classes',
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Secunderabad | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Secunderabad Hyderabad. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Personalized batches & doubt clearing. Book free demo!',
+  keywords: [
+    'NEET coaching Secunderabad',
+    'biology tuition Secunderabad',
+    'NEET classes Secunderabad Hyderabad',
+    'best NEET tutor Secunderabad',
+    'medical entrance coaching Secunderabad',
+    'NEET preparation Hyderabad',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Secunderabad | 98% Success Rate | Cerebrum',
     description:
-      'Premium online coaching - no Secunderabad-Hyderabad commute. World-class teaching from home.',
+      'Join #1 NEET coaching in Secunderabad Hyderabad. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-secunderabad-hyderabad`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
   },
-  {
-    icon: Users,
-    title: 'Elite Small Batches (10-15)',
-    description: 'Exclusive batches for Secunderabad students with personalized attention.',
-  },
-  {
-    icon: Award,
-    title: 'AIIMS Trained Faculty',
-    description: 'Expert doctors and teachers from premier medical institutions.',
-  },
-  {
-    icon: BookOpen,
-    title: 'Telangana & CBSE Expert',
-    description: 'Complete coverage of TSBIE Inter syllabus and CBSE for NEET.',
-  },
-  {
-    icon: Clock,
-    title: 'Flexible Timings',
-    description: 'Morning, afternoon, evening batches to complement school schedules.',
-  },
-  {
-    icon: Shield,
-    title: 'Zero Commute Stress',
-    description: 'No traffic to coaching hubs in Ameerpet. Learn from your residence.',
-  },
-]
-
-const successMetrics = [
-  { label: 'Success Rate', value: '94.2%', icon: Trophy },
-  { label: 'Top Score 2024', value: '358', icon: Star },
-  { label: 'Secunderabad Students', value: '850+', icon: Users },
-  { label: 'Premium Schools', value: '15+', icon: GraduationCap },
-]
-
-const faqs = [
-  {
-    question: 'Why do Secunderabad students choose online NEET coaching?',
-    answer:
-      "Secunderabad has excellent schools like Pallavi Model School, Delhi Public School, and St. Ann's with demanding schedules. Our online classes offer flexibility that physical coaching in Ameerpet cannot. Save 2-3 hours daily on traffic. Our 94.2% success rate proves online is equally effective.",
-  },
-  {
-    question: 'Which areas in Secunderabad do you serve?',
-    answer:
-      'We serve all Secunderabad localities including Secunderabad Main, Begumpet, Trimulgherry, Alwal, Malkajgiri, Tarnaka, Marredpally, Bowenpally, and all surrounding areas. Students from anywhere in Twin Cities can join our online live classes.',
-  },
-  {
-    question: 'What is the fee for premium NEET coaching in Secunderabad?',
-    answer:
-      'Our complete NEET Biology course ranges from Rs 24,000 to Rs 68,000 per year depending on the program chosen. This is competitive with Ameerpet coaching centers while offering superior flexibility and smaller batches. EMI options available.',
-  },
-  {
-    question: 'How does this compare to coaching centers in Ameerpet or Kukatpally?',
-    answer:
-      'Unlike physical coaching centers where batches have 50-100 students, we limit batches to 10-15 students. This means every doubt gets addressed, every student gets personal attention. Plus, you save hours on Hyderabad traffic daily.',
-  },
-  {
-    question: 'What medical colleges can Secunderabad students target?',
-    answer:
-      'With proper NEET preparation, Secunderabad students can target top colleges like Gandhi Medical College, Osmania Medical College, Deccan College of Medical Sciences, ESIC Medical College, and all-India institutes like AIIMS and JIPMER.',
-  },
-  {
-    question: 'Do you cover Telangana Inter (TSBIE) syllabus?',
-    answer:
-      'Yes! We cater to both Telangana State Board (TSBIE Inter) and CBSE students. Our program bridges TSBIE syllabus with NCERT for complete NEET preparation. 75-80% syllabus overlap means focused gap filling.',
-  },
-]
-
-const premiumSchools = [
-  'Pallavi Model School',
-  'Delhi Public School Secunderabad',
-  'St. Anns High School',
-  'Bharatiya Vidya Bhavan',
-  'Glendale Academy',
-  'Rosary Convent School',
-  'St. Patricks High School',
-  'Silver Oaks International',
-  'Oakridge International',
-  'Meridian School',
-]
-
-const neetTools = [
-  { name: 'NEET Rank Predictor', href: '/neet-rank-predictor', icon: Calculator },
-  { name: 'College Predictor', href: '/neet-college-predictor', icon: Building },
-  { name: 'Study Plan Generator', href: '/neet-study-plan-generator', icon: Target },
-  { name: 'NEET Exam Countdown', href: '/neet-exam-countdown', icon: Clock },
-]
-
-const whySecunderabad = [
-  {
-    icon: Sparkles,
-    title: 'Premium Quality, Zero Commute',
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Secunderabad | 98% Success Rate',
     description:
-      'Get world-class NEET coaching without traveling to Ameerpet. No traffic hassle to coaching hubs.',
+      'Join #1 NEET coaching in Secunderabad Hyderabad. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
   },
-  {
-    icon: Building,
-    title: 'Twin Cities Expert',
-    description:
-      'Same faculty that teaches Jubilee Hills & Gachibowli elite. Now accessible from Secunderabad.',
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-secunderabad-hyderabad`,
   },
-  {
-    icon: GraduationCap,
-    title: 'Defence Family Friendly',
-    description:
-      'Flexible timings that work with defence and corporate families. Evening and weekend options.',
-  },
-]
+}
 
-export default function NeetCoachingSecunderabadPage() {
-  const handleWhatsAppClick = () => {
-    if (typeof window !== 'undefined' && (window as any).gtag) {
-      ;(window as any).gtag('event', 'whatsapp_click', {
-        event_category: 'conversion',
-        event_label: 'secunderabad_neet_page',
-      })
-    }
-    window.open(`https://wa.me/${WHATSAPP_NUMBER}?text=${WHATSAPP_MESSAGE}`, '_blank')
-  }
-
+export default function NEETCoachingSecunderabadPage() {
   return (
-    <div className="min-h-screen">
-      <CitySchema
-        cityName="Secunderabad"
-        citySlug="secunderabad-hyderabad"
-        state="Telangana"
-        localities={localities.map((l) => l.name)}
-        faqs={faqs}
-        studentCount="850"
-        coordinates={{ lat: '17.4399', lng: '78.4983' }}
+    <>
+      <LocalitySchema
+        locality="Secunderabad"
+        slug="neet-coaching-secunderabad-hyderabad"
+        pageTitle="Best NEET Coaching in Secunderabad"
+        pageDescription="Join #1 NEET coaching in Secunderabad Hyderabad. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
       />
-
-      {/* Hero Section */}
-      <section className="relative bg-gradient-to-br from-[#1e3a5f] via-[#2d5a87] to-[#3d7ab5] text-white py-20 overflow-hidden">
-        <div className="absolute inset-0 bg-black/10" />
-        <div className="relative max-w-7xl mx-auto px-4">
-          <motion.div
-            className="text-center max-w-4xl mx-auto"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-          >
-            <div className="inline-flex items-center bg-white/20 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
-              <MapPin className="w-5 h-5 mr-2" />
-              Twin City | Premium NEET Coaching
-            </div>
-            <h1 className="text-4xl md:text-6xl font-bold mb-6">
-              Best <span className="text-[#4ade80]">NEET Coaching in Secunderabad</span>, Hyderabad
-            </h1>
-            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
-              Begumpet | Trimulgherry | Alwal | Malkajgiri | Tarnaka
-            </h2>
-            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
-              Premium NEET Biology coaching for Secunderabad&apos;s best schools. 94.2% success
-              rate, AIIMS faculty, zero Ameerpet traffic. Join 850+ students from Pallavi, DPS, St.
-              Ann&apos;s!
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-8">
-              <Button
-                variant="secondary"
-                size="xl"
-                onClick={handleWhatsAppClick}
-                className="bg-[#25D366] text-white hover:bg-[#20BD5A] flex items-center justify-center gap-2"
-              >
-                <MessageCircle className="w-6 h-6" />
-                <span>WhatsApp Us Now</span>
-              </Button>
-              <Link href="/demo-booking">
-                <Button
-                  variant="secondary"
-                  size="xl"
-                  className="bg-[#4ade80] text-[#1e3a5f] hover:bg-[#22c55e]"
-                >
-                  <Play className="w-5 h-5 mr-2" />
-                  Book Free Demo Class
-                </Button>
-              </Link>
-            </div>
-            <div className="flex items-center justify-center gap-2 text-white/90 mb-12">
-              <Phone className="w-5 h-5" />
-              <span>Call: </span>
-              <a href="tel:+918826444334" className="font-bold hover:text-[#4ade80]">
-                +91-88264-44334
-              </a>
-            </div>
-            <div className="grid md:grid-cols-4 gap-6 max-w-4xl mx-auto">
-              {successMetrics.map((metric, index) => (
-                <motion.div
-                  key={metric.label}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: 0.2 + index * 0.1 }}
-                  className="bg-white/10 backdrop-blur-sm rounded-xl p-6"
-                >
-                  <metric.icon className="w-8 h-8 mx-auto mb-2 text-[#4ade80]" />
-                  <div className="text-2xl font-bold">{metric.value}</div>
-                  <div className="text-sm opacity-80">{metric.label}</div>
-                </motion.div>
-              ))}
-            </div>
-          </motion.div>
-        </div>
-      </section>
-
-      {/* NEET Tools Section */}
-      <section className="py-12 bg-gradient-to-r from-[#1e3a5f] to-[#2d5a87] text-white">
-        <div className="max-w-7xl mx-auto px-4">
-          <div className="text-center mb-8">
-            <h2 className="text-2xl md:text-3xl font-bold mb-2">Free NEET Preparation Tools</h2>
-          </div>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            {neetTools.map((tool) => (
-              <Link
-                key={tool.name}
-                href={tool.href}
-                className="bg-white/10 hover:bg-white/20 backdrop-blur-sm rounded-xl p-4 text-center transition-all hover:scale-105"
-              >
-                <tool.icon className="w-8 h-8 mx-auto mb-2" />
-                <span className="text-sm font-medium">{tool.name}</span>
-              </Link>
-            ))}
-          </div>
-          <div className="text-center mt-6">
-            <Link href="/neet-tools">
-              <Button
-                variant="outline"
-                className="border-white text-white hover:bg-white hover:text-[#1e3a5f]"
-              >
-                View All NEET Tools <ArrowRight className="w-4 h-4 ml-2" />
-              </Button>
-            </Link>
-          </div>
-        </div>
-      </section>
-
-      {/* Localities Section */}
-      <section className="py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div className="text-center mb-16">
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              NEET Coaching Across Secunderabad
-            </h2>
-          </motion.div>
-          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {localities.map((locality, index) => (
-              <motion.div
-                key={locality.name}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.05 }}
-                viewport={{ once: true }}
-              >
-                <div
-                  className={`bg-white rounded-xl shadow-lg p-6 hover:shadow-xl transition-all hover:-translate-y-1 ${locality.priority === 'high' ? 'ring-2 ring-[#1e3a5f]' : ''}`}
-                >
-                  <div className="flex items-center justify-between mb-2">
-                    <h3 className="text-lg font-bold text-gray-900">{locality.name}</h3>
-                    <MapPin className="w-5 h-5 text-[#1e3a5f]" />
-                  </div>
-                  <div className="text-2xl font-bold text-[#1e3a5f] mb-1">{locality.students}</div>
-                  <div className="text-sm text-gray-500">{locality.highlight}</div>
-                </div>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Why Secunderabad Section */}
-      <section className="py-20 bg-white">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div className="text-center mb-16">
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              Why Secunderabad Families Choose Cerebrum
-            </h2>
-          </motion.div>
-          <div className="grid md:grid-cols-3 gap-8 mb-16">
-            {whySecunderabad.map((item, index) => (
-              <motion.div
-                key={item.title}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-gray-50 rounded-xl p-8 border border-gray-200"
-              >
-                <item.icon className="w-12 h-12 text-[#1e3a5f] mb-4" />
-                <h3 className="text-xl font-bold text-gray-900 mb-2">{item.title}</h3>
-                <p className="text-gray-600">{item.description}</p>
-              </motion.div>
-            ))}
-          </div>
-          <div className="bg-gray-50 rounded-2xl p-8">
-            <h3 className="text-2xl font-bold text-gray-900 mb-6 text-center">
-              Students from These Secunderabad Schools Trust Us
-            </h3>
-            <div className="flex flex-wrap justify-center gap-4">
-              {premiumSchools.map((school) => (
-                <span
-                  key={school}
-                  className="bg-white text-gray-700 px-4 py-2 rounded-full font-medium shadow-sm"
-                >
-                  {school}
-                </span>
-              ))}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Features Section */}
-      <section className="py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div className="text-center mb-16">
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              Premium NEET Biology Coaching Features
-            </h2>
-          </motion.div>
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {features.map((feature, index) => (
-              <motion.div
-                key={feature.title}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-white rounded-xl p-8 shadow-lg"
-              >
-                <feature.icon className="w-12 h-12 text-[#1e3a5f] mb-4" />
-                <h3 className="text-xl font-bold text-gray-900 mb-2">{feature.title}</h3>
-                <p className="text-gray-600">{feature.description}</p>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <VideoTestimonialsSection />
-
-      {/* FAQs Section */}
-      <section className="py-20 bg-white">
-        <div className="max-w-4xl mx-auto px-4">
-          <motion.div className="text-center mb-16">
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              FAQs - NEET Coaching Secunderabad
-            </h2>
-          </motion.div>
-          <div className="space-y-6">
-            {faqs.map((faq, index) => (
-              <motion.div
-                key={faq.question}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-gray-50 rounded-xl p-8"
-                itemScope
-                itemType="https://schema.org/Question"
-              >
-                <h3
-                  className="text-xl font-bold text-gray-900 mb-4 flex items-start"
-                  itemProp="name"
-                >
-                  <MessageCircle className="w-6 h-6 mr-3 text-[#1e3a5f] flex-shrink-0 mt-1" />
-                  {faq.question}
-                </h3>
-                <div itemScope itemType="https://schema.org/Answer" itemProp="acceptedAnswer">
-                  <p className="text-gray-700 leading-relaxed ml-9" itemProp="text">
-                    {faq.answer}
-                  </p>
-                </div>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Final CTA Section */}
-      <section className="py-20 bg-gradient-to-r from-[#1e3a5f] via-[#2d5a87] to-[#3d7ab5] text-white">
-        <div className="max-w-4xl mx-auto px-4 text-center">
-          <motion.div initial={{ opacity: 0, y: 20 }} whileInView={{ opacity: 1, y: 0 }}>
-            <h2 className="text-3xl md:text-5xl font-bold mb-6">
-              Join Secunderabad&apos;s Elite NEET Aspirants
-            </h2>
-            <p className="text-xl md:text-2xl mb-8 opacity-90">
-              94.2% success rate, AIIMS faculty, premium small batches. No Ameerpet commute needed!
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-8">
-              <Button
-                variant="secondary"
-                size="xl"
-                onClick={handleWhatsAppClick}
-                className="bg-[#25D366] text-white hover:bg-[#20BD5A] flex items-center justify-center gap-2"
-              >
-                <MessageCircle className="w-6 h-6" />
-                <span>WhatsApp Us Now</span>
-              </Button>
-              <Link href="/demo-booking">
-                <Button
-                  variant="secondary"
-                  size="xl"
-                  className="bg-white text-[#1e3a5f] hover:bg-gray-100"
-                >
-                  <Play className="w-5 h-5 mr-2" />
-                  Book Free Demo Class
-                </Button>
-              </Link>
-            </div>
-            <div className="flex items-center justify-center gap-2 text-white/90">
-              <Phone className="w-5 h-5" />
-              <span>Call: </span>
-              <a href="tel:+918826444334" className="font-bold hover:text-[#4ade80]">
-                +91-88264-44334
-              </a>
-            </div>
-          </motion.div>
-        </div>
-      </section>
-    </div>
+      <PageContent />
+    </>
   )
 }

--- a/src/app/neet-coaching-sg-highway-ahmedabad/PageContent.tsx
+++ b/src/app/neet-coaching-sg-highway-ahmedabad/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Shield,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const sgHighwayAreas = [
+  { name: 'SG Highway', distance: '0 km', landmark: 'Premium Corridor' },
+  { name: 'Bodakdev', distance: '3 km', landmark: 'Premium Residential' },
+  { name: 'Satellite Road', distance: '5 km', landmark: 'Upscale Zone' },
+  { name: 'Prahlad Nagar', distance: '4 km', landmark: 'Corporate Hub' },
+  { name: 'Thaltej', distance: '6 km', landmark: 'IT Park Area' },
+  { name: 'Vastrapur', distance: '7 km', landmark: 'Premium Locality' },
+  { name: 'Vesu', distance: '8 km', landmark: 'South Ahmedabad' },
+  { name: 'Mahanagar', distance: '9 km', landmark: 'Residential Area' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Building,
+    title: 'SG Highway Business Families Trust Us',
+    description:
+      'Top choice for premium SG Highway business families and industrialists. Trusted by corporate executives seeking excellent NEET coaching with proven results.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Successful coaching of students from Udgam, Ahmedabad International School, GD Goenka, and top Ahmedabad institutions.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'Expert Medical Faculty',
+    description:
+      'NEET biology coaching by experienced medical professionals with 15+ years expertise teaching premium SG Highway families.',
+  },
+  {
+    icon: Star,
+    title: 'Top NEET Scores',
+    description:
+      'SG Highway students achieve 685+ NEET scores and secure AIIMS, BIT Pilani, and other prestigious medical college admissions.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Why choose your NEET coaching for SG Highway families?',
+    answer:
+      'SG Highway families value quality, results, and professional excellence. We provide premium online NEET coaching with expert faculty, structured curriculum, and proven 98% success rate. Our coaching matches the high standards of business families.',
+  },
+  {
+    question: 'Do you have classes near SG Highway?',
+    answer:
+      'Our NEET coaching is delivered through premium online live classes. This flexibility suits SG Highway professionals perfectly. We provide recorded lectures, comprehensive material, regular tests, and personalized guidance.',
+  },
+  {
+    question: 'Which schools do your Ahmedabad students come from?',
+    answer:
+      'We coach students from Udgam, Ahmedabad International School, GD Goenka, Vibrant Academy, and other premier Ahmedabad schools.',
+  },
+  {
+    question: 'What makes your NEET coaching different?',
+    answer:
+      'Our coaching combines expert faculty, structured approach, regular assessments, and personalized attention. We focus on conceptual clarity and application-based learning - the foundation of NEET success.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching SG Highway',
+  description: 'Best NEET Coaching for SG Highway Ahmedabad - Trusted by Business Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-sg-highway-ahmedabad',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Ahmedabad',
+    addressRegion: 'Gujarat',
+    addressCountry: 'IN',
+  },
+  areaServed: ['SG Highway', 'Bodakdev', 'Satellite', 'Prahlad Nagar', 'Ahmedabad'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Building className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Business Families | Expert Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">SG Highway Ahmedabad</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium NEET Coaching for Ahmedabad's Business Elite
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Expert NEET coaching for SG Highway, Bodakdev, and premium Ahmedabad areas. Learn from
+              accomplished medical faculty trusted by <strong>industrialists and business families</strong>. Premium
+              online classes with proven 685+ NEET results.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20SG%20Highway%20Ahmedabad%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Premium</div>
+                <div className="text-sm opacity-80">Corridor</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Star className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">685+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              SG Highway & Premium Ahmedabad Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Ahmedabad's premium corridors
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {sgHighwayAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why SG Highway Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              SG Highway Students, Master NEET with Excellence!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium NEET coaching for Ahmedabad's most ambitious families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20SG%20Highway%20Ahmedabad%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-ahmedabad"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Ahmedabad NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-bodakdev-ahmedabad"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Bodakdev Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-sg-highway-ahmedabad/page.tsx
+++ b/src/app/neet-coaching-sg-highway-ahmedabad/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'SG Highway'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in SG Highway Ahmedabad | Premium | Cerebrum',
+  description:
+    'Join #1 NEET coaching in SG Highway, Ahmedabad. Expert faculty, proven 98% success rate, 695/720 top score. Premium coaching for business families. Book free demo!',
+  keywords: [
+    'NEET coaching SG Highway',
+    'biology tuition SG Highway Ahmedabad',
+    'NEET classes SG Highway',
+    'best NEET tutor Ahmedabad',
+    'medical entrance SG Highway',
+    'NEET preparation premium Ahmedabad',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in SG Highway Ahmedabad | Premium | Cerebrum',
+    description:
+      'Join #1 NEET coaching in SG Highway, Ahmedabad. Expert faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-sg-highway-ahmedabad`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in SG Highway Ahmedabad | Premium',
+    description:
+      'Join #1 NEET coaching in SG Highway, Ahmedabad. Expert faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-sg-highway-ahmedabad`,
+  },
+}
+
+export default function NEETCoachingSGHighwayAhmedabadPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="SG Highway"
+        slug="neet-coaching-sg-highway-ahmedabad"
+        pageTitle="Best NEET Coaching in SG Highway"
+        pageDescription="Join #1 NEET coaching in SG Highway, Ahmedabad. Expert faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-t-nagar-chennai/PageContent.tsx
+++ b/src/app/neet-coaching-t-nagar-chennai/PageContent.tsx
@@ -1,0 +1,383 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  ShoppingCart,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const tnagarAreas = [
+{ name: 'T Nagar', distance: '15 km', landmark: 'Premium Commercial' },
+  { name: 'Pondy Bazaar', distance: '16 km', landmark: 'Business Hub' },
+  { name: 'Mambalam', distance: '14 km', landmark: 'Residential' },
+  { name: 'Kodambakkam', distance: '17 km', landmark: 'Film Industry' },
+  { name: 'West Mambalam', distance: '18 km', landmark: 'Residential Zone' },
+  { name: 'Vadapalani', distance: '19 km', landmark: 'Business Area' },
+  { name: 'Nandanam', distance: '16 km', landmark: 'IT Zone' },
+  { name: 'Chamiers Road', distance: '20 km', landmark: 'Premium Residential' }
+]
+
+const whyChooseUs = [
+
+]
+
+const faqs = [
+
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching T Nagar',
+  description: 'Best NEET Coaching for T Nagar Chennai - Trusted by Premium Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-t-nagar-chennai',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['T Nagar', 'Pondy Bazaar', 'Mambalam', 'Kodambakkam', 'West Mambalam'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ { __html: JSON.stringify(faqSchema) } }
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ { __html: JSON.stringify(localBusinessSchema) } }
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <ShoppingCart className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Premium Commercial Families
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">T Nagar</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Thyagaraya Nagar Premium Commercial Zone
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Premium NEET coaching for T Nagar, Pondy Bazaar, commercial families & nearby areas. Learn from Dr. Shekhar C Singh, AIIMS Alumnus - trusted by business families.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20T%20Nagar%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <ShoppingCart className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Premium</div>
+                <div className="text-sm opacity-80">Commercial</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">680+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              T Nagar & Nearby Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Chennai premium families
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {tnagarAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={ { animationDelay: `${index * 50}ms` } }
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why T Nagar Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={ { animationDelay: `${index * 100}ms` } }
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={ { animationDelay: `${index * 100}ms` } }
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              T Nagar Students, Excel in NEET!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium coaching for business families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20T%20Nagar%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-chennai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Chennai NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-mylapore-chennai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Mylapore Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-t-nagar-chennai/page.tsx
+++ b/src/app/neet-coaching-t-nagar-chennai/page.tsx
@@ -1,468 +1,68 @@
-'use client'
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
 
-import { motion } from 'framer-motion'
-import {
-  MapPin,
-  Users,
-  Trophy,
-  Star,
-  Award,
-  BookOpen,
-  Clock,
-  Shield,
-  Video,
-  MessageCircle,
-  Play,
-  ArrowRight,
-  GraduationCap,
-  Building,
-  Phone,
-  Calculator,
-  Target,
-  Sparkles,
-} from 'lucide-react'
-import { Button } from '@/components/ui/Button'
-import Link from 'next/link'
-import { VideoTestimonialsSection } from '@/components/testimonials/VideoTestimonialsSection'
-import { CitySchema } from '@/components/seo/CitySchema'
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'T Nagar'
 
-const WHATSAPP_NUMBER = '918826444334'
-const WHATSAPP_MESSAGE = encodeURIComponent(
-  'Hi! I am interested in NEET coaching in T Nagar Chennai. Please share details.'
-)
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
 
-const localities = [
-  { name: 'T. Nagar', students: '320+', highlight: 'Premium Hub', priority: 'high' },
-  { name: 'Nungambakkam', students: '240+', highlight: 'Elite Locality', priority: 'high' },
-  { name: 'Kodambakkam', students: '180+', highlight: 'Film City', priority: 'high' },
-  { name: 'Vadapalani', students: '150+', highlight: 'Temple Town', priority: 'high' },
-  { name: 'Ashok Nagar', students: '130+', highlight: 'Residential', priority: 'medium' },
-  { name: 'West Mambalam', students: '140+', highlight: 'Central Chennai', priority: 'medium' },
-  { name: 'Saidapet', students: '110+', highlight: 'Metro Connected', priority: 'medium' },
-  { name: 'Teynampet', students: '170+', highlight: 'Commercial Hub', priority: 'high' },
-]
-
-const features = [
-  {
-    icon: Video,
-    title: 'Live Interactive Classes',
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in T Nagar | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in T Nagar Chennai. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Personalized batches & doubt clearing. Book free demo!',
+  keywords: [
+    'NEET coaching T Nagar',
+    'biology tuition T Nagar',
+    'NEET classes T Nagar Chennai',
+    'best NEET tutor T Nagar',
+    'medical entrance coaching T Nagar',
+    'NEET preparation Chennai',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in T Nagar | 98% Success Rate | Cerebrum',
     description:
-      'Premium online coaching - no Chennai traffic. World-class teaching from your T Nagar home.',
+      'Join #1 NEET coaching in T Nagar Chennai. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-t-nagar-chennai`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
   },
-  {
-    icon: Users,
-    title: 'Elite Small Batches (10-15)',
-    description: 'Exclusive batches for T Nagar students with personalized attention.',
-  },
-  {
-    icon: Award,
-    title: 'AIIMS Trained Faculty',
-    description: 'Expert doctors and teachers from premier medical institutions.',
-  },
-  {
-    icon: BookOpen,
-    title: 'Tamil Nadu & CBSE Expert',
-    description: 'Complete coverage of Samacheer Kalvi and CBSE for NEET.',
-  },
-  {
-    icon: Clock,
-    title: 'Flexible Timings',
-    description: 'Morning, afternoon, evening batches to complement school schedules.',
-  },
-  {
-    icon: Shield,
-    title: 'Zero Commute Stress',
-    description: 'No traffic to coaching hubs. Learn from your premium T Nagar residence.',
-  },
-]
-
-const successMetrics = [
-  { label: 'Success Rate', value: '94.2%', icon: Trophy },
-  { label: 'Top Score 2024', value: '358', icon: Star },
-  { label: 'T Nagar Students', value: '980+', icon: Users },
-  { label: 'Premium Schools', value: '22+', icon: GraduationCap },
-]
-
-const faqs = [
-  {
-    question: 'Why do T Nagar students choose online NEET coaching?',
-    answer:
-      'T Nagar has excellent schools like PSBB, DAV, and Vidya Mandir with demanding schedules. Our online classes offer flexibility that physical coaching cannot. Save 2-3 hours daily on Chennai traffic. Our 94.2% success rate proves online is equally effective.',
-  },
-  {
-    question: 'Which areas in T Nagar do you serve?',
-    answer:
-      'We serve all T Nagar localities including T Nagar Main, Nungambakkam, Kodambakkam, Vadapalani, Ashok Nagar, West Mambalam, Saidapet, Teynampet, and all surrounding areas. Students from anywhere in Central Chennai can join our online live classes.',
-  },
-  {
-    question: 'What is the fee for premium NEET coaching in T Nagar?',
-    answer:
-      'Our complete NEET Biology course ranges from Rs 24,000 to Rs 68,000 per year depending on the program chosen. This is competitive with T Nagar coaching centers while offering superior flexibility and smaller batches. EMI options available.',
-  },
-  {
-    question: 'How does this compare to coaching centers in Nungambakkam or Adyar?',
-    answer:
-      'Unlike physical coaching centers where batches have 50-100 students, we limit batches to 10-15 students. This means every doubt gets addressed, every student gets personal attention. Plus, you save hours on Chennai traffic daily.',
-  },
-  {
-    question: 'What medical colleges can T Nagar students target?',
-    answer:
-      'With proper NEET preparation, T Nagar students can target top colleges like Madras Medical College, Stanley Medical College, Kilpauk Medical College, Sri Ramachandra, and all-India institutes like AIIMS, JIPMER Puducherry.',
-  },
-  {
-    question: 'Do you cover Tamil Nadu State Board (Samacheer Kalvi) syllabus?',
-    answer:
-      'Yes! We cater to both Tamil Nadu State Board (Samacheer Kalvi) and CBSE students. Our program bridges Samacheer Kalvi syllabus with NCERT for complete NEET preparation. 70-75% syllabus overlap means focused gap filling.',
-  },
-]
-
-const premiumSchools = [
-  'PSBB School',
-  'DAV Boys & Girls',
-  'Vidya Mandir',
-  'Chettinad Vidyashram',
-  'Chinmaya Vidyalaya',
-  'Sishya School',
-  'Lady Andal Venkatasubba Rao',
-  'P.S. Senior Secondary',
-  'Padma Seshadri Bala Bhavan',
-  'The School KFI',
-]
-
-const neetTools = [
-  { name: 'NEET Rank Predictor', href: '/neet-rank-predictor', icon: Calculator },
-  { name: 'College Predictor', href: '/neet-college-predictor', icon: Building },
-  { name: 'Study Plan Generator', href: '/neet-study-plan-generator', icon: Target },
-  { name: 'NEET Exam Countdown', href: '/neet-exam-countdown', icon: Clock },
-]
-
-const whyTNagar = [
-  {
-    icon: Sparkles,
-    title: 'Premium Quality, Zero Commute',
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in T Nagar | 98% Success Rate',
     description:
-      'Get world-class NEET coaching without leaving T Nagar. No traffic hassle to coaching hubs.',
+      'Join #1 NEET coaching in T Nagar Chennai. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
   },
-  {
-    icon: Building,
-    title: 'Chennai Elite Standard',
-    description: 'Same faculty that teaches Adyar & Anna Nagar elite. Now accessible from T Nagar.',
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-t-nagar-chennai`,
   },
-  {
-    icon: GraduationCap,
-    title: 'PSBB Network Friendly',
-    description:
-      "Many PSBB school students. We understand your school's academic rigor and schedule.",
-  },
-]
+}
 
-export default function NeetCoachingTNagarPage() {
-  const handleWhatsAppClick = () => {
-    if (typeof window !== 'undefined' && (window as any).gtag) {
-      ;(window as any).gtag('event', 'whatsapp_click', {
-        event_category: 'conversion',
-        event_label: 'tnagar_neet_page',
-      })
-    }
-    window.open(`https://wa.me/${WHATSAPP_NUMBER}?text=${WHATSAPP_MESSAGE}`, '_blank')
-  }
-
+export default function NEETCoachingTNagarPage() {
   return (
-    <div className="min-h-screen">
-      <CitySchema
-        cityName="T Nagar"
-        citySlug="t-nagar-chennai"
-        state="Tamil Nadu"
-        localities={localities.map((l) => l.name)}
-        faqs={faqs}
-        studentCount="980"
-        coordinates={{ lat: '13.0418', lng: '80.2341' }}
+    <>
+      <LocalitySchema
+        locality="T Nagar"
+        slug="neet-coaching-t-nagar-chennai"
+        pageTitle="Best NEET Coaching in T Nagar"
+        pageDescription="Join #1 NEET coaching in T Nagar Chennai. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
       />
-
-      {/* Hero Section */}
-      <section className="relative bg-gradient-to-br from-[#1e3a5f] via-[#2d5a87] to-[#3d7ab5] text-white py-20 overflow-hidden">
-        <div className="absolute inset-0 bg-black/10" />
-        <div className="relative max-w-7xl mx-auto px-4">
-          <motion.div
-            className="text-center max-w-4xl mx-auto"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-          >
-            <div className="inline-flex items-center bg-white/20 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
-              <MapPin className="w-5 h-5 mr-2" />
-              Chennai Premium Hub | NEET Coaching
-            </div>
-            <h1 className="text-4xl md:text-6xl font-bold mb-6">
-              Best <span className="text-[#4ade80]">NEET Coaching in T Nagar</span>, Chennai
-            </h1>
-            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
-              Nungambakkam | Kodambakkam | Vadapalani | Teynampet | Ashok Nagar
-            </h2>
-            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
-              Premium NEET Biology coaching for T Nagar&apos;s best schools. 94.2% success rate,
-              AIIMS faculty, zero Chennai traffic. Join 980+ students from PSBB, DAV, Vidya Mandir!
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-8">
-              <Button
-                variant="secondary"
-                size="xl"
-                onClick={handleWhatsAppClick}
-                className="bg-[#25D366] text-white hover:bg-[#20BD5A] flex items-center justify-center gap-2"
-              >
-                <MessageCircle className="w-6 h-6" />
-                <span>WhatsApp Us Now</span>
-              </Button>
-              <Link href="/demo-booking">
-                <Button
-                  variant="secondary"
-                  size="xl"
-                  className="bg-[#4ade80] text-[#1e3a5f] hover:bg-[#22c55e]"
-                >
-                  <Play className="w-5 h-5 mr-2" />
-                  Book Free Demo Class
-                </Button>
-              </Link>
-            </div>
-            <div className="flex items-center justify-center gap-2 text-white/90 mb-12">
-              <Phone className="w-5 h-5" />
-              <span>Call: </span>
-              <a href="tel:+918826444334" className="font-bold hover:text-[#4ade80]">
-                +91-88264-44334
-              </a>
-            </div>
-            <div className="grid md:grid-cols-4 gap-6 max-w-4xl mx-auto">
-              {successMetrics.map((metric, index) => (
-                <motion.div
-                  key={metric.label}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: 0.2 + index * 0.1 }}
-                  className="bg-white/10 backdrop-blur-sm rounded-xl p-6"
-                >
-                  <metric.icon className="w-8 h-8 mx-auto mb-2 text-[#4ade80]" />
-                  <div className="text-2xl font-bold">{metric.value}</div>
-                  <div className="text-sm opacity-80">{metric.label}</div>
-                </motion.div>
-              ))}
-            </div>
-          </motion.div>
-        </div>
-      </section>
-
-      {/* NEET Tools Section */}
-      <section className="py-12 bg-gradient-to-r from-[#1e3a5f] to-[#2d5a87] text-white">
-        <div className="max-w-7xl mx-auto px-4">
-          <div className="text-center mb-8">
-            <h2 className="text-2xl md:text-3xl font-bold mb-2">Free NEET Preparation Tools</h2>
-          </div>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            {neetTools.map((tool) => (
-              <Link
-                key={tool.name}
-                href={tool.href}
-                className="bg-white/10 hover:bg-white/20 backdrop-blur-sm rounded-xl p-4 text-center transition-all hover:scale-105"
-              >
-                <tool.icon className="w-8 h-8 mx-auto mb-2" />
-                <span className="text-sm font-medium">{tool.name}</span>
-              </Link>
-            ))}
-          </div>
-          <div className="text-center mt-6">
-            <Link href="/neet-tools">
-              <Button
-                variant="outline"
-                className="border-white text-white hover:bg-white hover:text-[#1e3a5f]"
-              >
-                View All NEET Tools <ArrowRight className="w-4 h-4 ml-2" />
-              </Button>
-            </Link>
-          </div>
-        </div>
-      </section>
-
-      {/* Localities Section */}
-      <section className="py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div className="text-center mb-16">
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              NEET Coaching Across T Nagar & Central Chennai
-            </h2>
-          </motion.div>
-          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {localities.map((locality, index) => (
-              <motion.div
-                key={locality.name}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.05 }}
-                viewport={{ once: true }}
-              >
-                <div
-                  className={`bg-white rounded-xl shadow-lg p-6 hover:shadow-xl transition-all hover:-translate-y-1 ${locality.priority === 'high' ? 'ring-2 ring-[#1e3a5f]' : ''}`}
-                >
-                  <div className="flex items-center justify-between mb-2">
-                    <h3 className="text-lg font-bold text-gray-900">{locality.name}</h3>
-                    <MapPin className="w-5 h-5 text-[#1e3a5f]" />
-                  </div>
-                  <div className="text-2xl font-bold text-[#1e3a5f] mb-1">{locality.students}</div>
-                  <div className="text-sm text-gray-500">{locality.highlight}</div>
-                </div>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Why T Nagar Section */}
-      <section className="py-20 bg-white">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div className="text-center mb-16">
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              Why T Nagar Families Choose Cerebrum
-            </h2>
-          </motion.div>
-          <div className="grid md:grid-cols-3 gap-8 mb-16">
-            {whyTNagar.map((item, index) => (
-              <motion.div
-                key={item.title}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-gray-50 rounded-xl p-8 border border-gray-200"
-              >
-                <item.icon className="w-12 h-12 text-[#1e3a5f] mb-4" />
-                <h3 className="text-xl font-bold text-gray-900 mb-2">{item.title}</h3>
-                <p className="text-gray-600">{item.description}</p>
-              </motion.div>
-            ))}
-          </div>
-          <div className="bg-gray-50 rounded-2xl p-8">
-            <h3 className="text-2xl font-bold text-gray-900 mb-6 text-center">
-              Students from These T Nagar Schools Trust Us
-            </h3>
-            <div className="flex flex-wrap justify-center gap-4">
-              {premiumSchools.map((school) => (
-                <span
-                  key={school}
-                  className="bg-white text-gray-700 px-4 py-2 rounded-full font-medium shadow-sm"
-                >
-                  {school}
-                </span>
-              ))}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Features Section */}
-      <section className="py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div className="text-center mb-16">
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              Premium NEET Biology Coaching Features
-            </h2>
-          </motion.div>
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {features.map((feature, index) => (
-              <motion.div
-                key={feature.title}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-white rounded-xl p-8 shadow-lg"
-              >
-                <feature.icon className="w-12 h-12 text-[#1e3a5f] mb-4" />
-                <h3 className="text-xl font-bold text-gray-900 mb-2">{feature.title}</h3>
-                <p className="text-gray-600">{feature.description}</p>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <VideoTestimonialsSection />
-
-      {/* FAQs Section */}
-      <section className="py-20 bg-white">
-        <div className="max-w-4xl mx-auto px-4">
-          <motion.div className="text-center mb-16">
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              FAQs - NEET Coaching T Nagar
-            </h2>
-          </motion.div>
-          <div className="space-y-6">
-            {faqs.map((faq, index) => (
-              <motion.div
-                key={faq.question}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-gray-50 rounded-xl p-8"
-                itemScope
-                itemType="https://schema.org/Question"
-              >
-                <h3
-                  className="text-xl font-bold text-gray-900 mb-4 flex items-start"
-                  itemProp="name"
-                >
-                  <MessageCircle className="w-6 h-6 mr-3 text-[#1e3a5f] flex-shrink-0 mt-1" />
-                  {faq.question}
-                </h3>
-                <div itemScope itemType="https://schema.org/Answer" itemProp="acceptedAnswer">
-                  <p className="text-gray-700 leading-relaxed ml-9" itemProp="text">
-                    {faq.answer}
-                  </p>
-                </div>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Final CTA Section */}
-      <section className="py-20 bg-gradient-to-r from-[#1e3a5f] via-[#2d5a87] to-[#3d7ab5] text-white">
-        <div className="max-w-4xl mx-auto px-4 text-center">
-          <motion.div initial={{ opacity: 0, y: 20 }} whileInView={{ opacity: 1, y: 0 }}>
-            <h2 className="text-3xl md:text-5xl font-bold mb-6">
-              Join T Nagar&apos;s Elite NEET Aspirants
-            </h2>
-            <p className="text-xl md:text-2xl mb-8 opacity-90">
-              94.2% success rate, AIIMS faculty, premium small batches. PSBB network specialists!
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-8">
-              <Button
-                variant="secondary"
-                size="xl"
-                onClick={handleWhatsAppClick}
-                className="bg-[#25D366] text-white hover:bg-[#20BD5A] flex items-center justify-center gap-2"
-              >
-                <MessageCircle className="w-6 h-6" />
-                <span>WhatsApp Us Now</span>
-              </Button>
-              <Link href="/demo-booking">
-                <Button
-                  variant="secondary"
-                  size="xl"
-                  className="bg-white text-[#1e3a5f] hover:bg-gray-100"
-                >
-                  <Play className="w-5 h-5 mr-2" />
-                  Book Free Demo Class
-                </Button>
-              </Link>
-            </div>
-            <div className="flex items-center justify-center gap-2 text-white/90">
-              <Phone className="w-5 h-5" />
-              <span>Call: </span>
-              <a href="tel:+918826444334" className="font-bold hover:text-[#4ade80]">
-                +91-88264-44334
-              </a>
-            </div>
-          </motion.div>
-        </div>
-      </section>
-    </div>
+      <PageContent />
+    </>
   )
 }

--- a/src/app/neet-coaching-thane-mumbai/PageContent.tsx
+++ b/src/app/neet-coaching-thane-mumbai/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Gem,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const thaneAreas = [
+  { name: 'Thane West', distance: '15 km', landmark: 'Premium Residential' },
+  { name: 'Ghodbunder Road', distance: '15 km', landmark: 'Premium Corridor' },
+  { name: 'Hiranandani Thane', distance: '14 km', landmark: 'Planned Community' },
+  { name: 'Majiwada', distance: '16 km', landmark: 'Residential Hub' },
+  { name: 'Waghbil', distance: '17 km', landmark: 'Thane East' },
+  { name: 'Kasarvadavali', distance: '14 km', landmark: 'IT Hub' },
+  { name: 'Vartak Nagar', distance: '16 km', landmark: 'Residential Area' },
+  { name: 'Pokharan Road', distance: '15 km', landmark: 'Premium Locality' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Gem,
+    title: 'Thane Premium Specialist',
+    description:
+      'Thane is rapidly developing into a premium gated community hub. We specialize in coaching for Ghodbunder Road, Hiranandani Thane, and upscale Thane West families.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Proven track record with students from elite schools across Thane and metro suburbs.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'AIIMS Faculty',
+    description:
+      'Dr. Shekhar C Singh, AIIMS Alumnus with 15+ years experience coaching motivated students from Thane premium communities.',
+  },
+  {
+    icon: Star,
+    title: 'Top Results',
+    description:
+      'Thane students scored 690+ in NEET with multiple AIIMS and prestigious medical college admissions.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Do you have a coaching center in Thane?',
+    answer:
+      'Our main center is in Greater Noida. For Thane residents, we offer premium live online NEET classes. Many Ghodbunder Road and Hiranandani Thane residents prefer online coaching for convenience. Our comprehensive material and recorded lectures ensure uninterrupted preparation.',
+  },
+  {
+    question: 'How do you support Thane gated community families?',
+    answer:
+      'Thane premium communities like Hiranandani Thane value structure and quality. We offer fixed schedules, personalized attention, detailed progress reports, and result-oriented teaching tailored for planned community residents.',
+  },
+  {
+    question: 'Which schools do Thane NEET students attend?',
+    answer:
+      'We have students from top schools including Cathedral School, Bombay Scottish, Jamnabai Narsee, and elite institutions across Thane. These academically rigorous schools align perfectly with our NEET preparation.',
+  },
+  {
+    question: 'What makes online coaching ideal for Thane students?',
+    answer:
+      'Online coaching offers flexibility for busy Thane families. Students can attend live classes during free hours and use recorded sessions during travels. Our detailed progress reports keep parents informed without requiring constant involvement.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Thane',
+  description: 'Best NEET Coaching for Thane - Premium gated community coaching',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-thane-mumbai',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Thane West', 'Ghodbunder Road', 'Hiranandani Thane', 'Majiwada', 'Kasarvadavali'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Gem className="w-5 h-5 mr-2 text-yellow-400" />
+              Premium Thane Coaching | AIIMS Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Thane</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Premium Biology Coaching for Thane&apos;s Gated Communities
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Exclusive NEET coaching for Thane West, Ghodbunder Road, Hiranandani Thane. Learn from
+              <strong> Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by premium Thane
+              families.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Thane%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Gem className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Premium</div>
+                <div className="text-sm opacity-80">Communities</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">690+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Thane & Surrounding Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Thane premium gated communities
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {thaneAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Thane Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Thane Students, Excel in NEET!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium NEET coaching for premium Thane families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Thane%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-mumbai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Mumbai NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-hiranandani-mumbai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Hiranandani Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-thane-mumbai/page.tsx
+++ b/src/app/neet-coaching-thane-mumbai/page.tsx
@@ -1,471 +1,69 @@
-'use client'
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
 
-import { motion } from 'framer-motion'
-import {
-  MapPin,
-  Users,
-  Trophy,
-  Star,
-  Award,
-  BookOpen,
-  Clock,
-  Shield,
-  Video,
-  MessageCircle,
-  Play,
-  ArrowRight,
-  GraduationCap,
-  Building,
-  Phone,
-  Calculator,
-  Target,
-  Sparkles,
-} from 'lucide-react'
-import { Button } from '@/components/ui/Button'
-import Link from 'next/link'
-import { VideoTestimonialsSection } from '@/components/testimonials/VideoTestimonialsSection'
-import { CitySchema } from '@/components/seo/CitySchema'
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Thane'
+const city = 'Mumbai'
 
-const WHATSAPP_NUMBER = '918826444334'
-const WHATSAPP_MESSAGE = encodeURIComponent(
-  'Hi! I am interested in NEET coaching in Thane Mumbai. Please share details.'
-)
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: `${locality}, ${city}`,
+})
 
-const localities = [
-  { name: 'Thane West', students: '280+', highlight: 'Premium Hub', priority: 'high' },
-  { name: 'Ghodbunder Road', students: '220+', highlight: 'IT Corridor', priority: 'high' },
-  { name: 'Hiranandani Estate', students: '180+', highlight: 'Ultra Premium', priority: 'high' },
-  { name: 'Majiwada', students: '150+', highlight: 'Central Thane', priority: 'high' },
-  { name: 'Kasarvadavali', students: '120+', highlight: 'Growing Fast', priority: 'medium' },
-  { name: 'Wagle Estate', students: '110+', highlight: 'Industrial Hub', priority: 'medium' },
-  { name: 'Kopri', students: '95+', highlight: 'East Thane', priority: 'medium' },
-  { name: 'Naupada', students: '130+', highlight: 'Commercial Center', priority: 'high' },
-]
-
-const features = [
-  {
-    icon: Video,
-    title: 'Live Interactive Classes',
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Thane | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Thane. Expert AIIMS faculty, 98% success rate. Ghodbunder Road, Hiranandani Thane, Majiwada. Premium online coaching. Book free demo!',
+  keywords: [
+    'NEET coaching Thane',
+    'biology tuition Thane',
+    'NEET classes Thane West',
+    'best NEET tutor Hiranandani Thane',
+    'medical entrance Ghodbunder Road',
+    'NEET preparation Thane',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Thane | 98% Success Rate | Cerebrum',
     description:
-      'Premium online coaching - no Eastern Express Highway traffic. World-class teaching from home.',
+      'Join #1 NEET coaching in Thane. Expert AIIMS faculty, 98% success rate. Premium gated communities. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-thane-mumbai`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
   },
-  {
-    icon: Users,
-    title: 'Elite Small Batches (10-15)',
-    description: 'Exclusive batches for Thane students with personalized attention.',
-  },
-  {
-    icon: Award,
-    title: 'AIIMS Trained Faculty',
-    description: 'Expert doctors and teachers from premier medical institutions.',
-  },
-  {
-    icon: BookOpen,
-    title: 'Complete Premium Package',
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Thane | 98% Success Rate',
     description:
-      'NCERT mastery, advanced materials, unlimited doubt sessions - everything included.',
+      'Join #1 NEET coaching in Thane. Expert AIIMS faculty. Premium gated community coaching. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
   },
-  {
-    icon: Clock,
-    title: 'Flexible Timings',
-    description: 'Morning, afternoon, evening batches to complement school schedules.',
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-thane-mumbai`,
   },
-  {
-    icon: Shield,
-    title: 'Zero Commute Stress',
-    description: 'No Mumbai traffic hassle. Learn from your premium Thane residence.',
-  },
-]
+}
 
-const successMetrics = [
-  { label: 'Success Rate', value: '94.2%', icon: Trophy },
-  { label: 'Top Score 2024', value: '358', icon: Star },
-  { label: 'Thane Students', value: '920+', icon: Users },
-  { label: 'Premium Schools', value: '18+', icon: GraduationCap },
-]
-
-const faqs = [
-  {
-    question: 'Why do Thane students choose online NEET coaching?',
-    answer:
-      'Thane has excellent schools like Hiranandani Foundation, DAV Public School, and Smt. Sulochanadevi Singhania School with demanding schedules. Our online classes offer flexibility that physical coaching in Mumbai cannot. Save 3-4 hours daily on EEH traffic. Our 94.2% success rate proves online is equally effective.',
-  },
-  {
-    question: 'Which areas in Thane do you serve?',
-    answer:
-      'We serve all Thane localities including Thane West, Ghodbunder Road, Hiranandani Estate, Majiwada, Kasarvadavali, Wagle Estate, Kopri, Naupada, and all surrounding areas. Students from anywhere in Thane district can join our online live classes.',
-  },
-  {
-    question: 'What is the fee for premium NEET coaching in Thane?',
-    answer:
-      'Our complete NEET Biology course ranges from Rs 24,000 to Rs 68,000 per year depending on the program chosen. This is competitive with Mumbai coaching centers while offering superior flexibility and smaller batches. EMI options available.',
-  },
-  {
-    question: 'How does this compare to coaching centers in Dadar or Andheri?',
-    answer:
-      'Unlike physical coaching centers where batches have 50-100 students, we limit batches to 10-15 students. This means every doubt gets addressed, every student gets personal attention. Plus, you save hours on Mumbai-Thane traffic daily.',
-  },
-  {
-    question: 'What medical colleges can Thane students target?',
-    answer:
-      'With proper NEET preparation, Thane students can target top colleges like Grant Medical College, KEM Hospital, Seth GS Medical College, Topiwala National Medical College, Lokmanya Tilak Municipal Medical College, and all-India institutes like AIIMS and JIPMER.',
-  },
-  {
-    question: 'Do you cover Maharashtra HSC and CBSE both?',
-    answer:
-      'Yes! We cater to both Maharashtra HSC Board and CBSE students from Thane. Our program bridges HSC/CBSE syllabus with NCERT for complete NEET preparation.',
-  },
-]
-
-const premiumSchools = [
-  'Hiranandani Foundation School',
-  'DAV Public School Thane',
-  'Smt. Sulochanadevi Singhania School',
-  'Podar International School',
-  'CP Goenka International',
-  'Orchids International Thane',
-  'Vasant Vihar High School',
-  'St. Johns High School',
-  'Bedekar Vidya Mandir',
-  'Ryan International Thane',
-]
-
-const neetTools = [
-  { name: 'NEET Rank Predictor', href: '/neet-rank-predictor', icon: Calculator },
-  { name: 'College Predictor', href: '/neet-college-predictor', icon: Building },
-  { name: 'Study Plan Generator', href: '/neet-study-plan-generator', icon: Target },
-  { name: 'NEET Exam Countdown', href: '/neet-exam-countdown', icon: Clock },
-]
-
-const whyThane = [
-  {
-    icon: Sparkles,
-    title: 'Premium Quality, Zero Commute',
-    description:
-      'Get world-class NEET coaching without traveling to Mumbai. No EEH traffic to coaching hubs.',
-  },
-  {
-    icon: Building,
-    title: 'Mumbai Quality in Thane',
-    description:
-      "Same faculty that teaches Mumbai's elite, now accessible from Thane. No compromise on quality.",
-  },
-  {
-    icon: GraduationCap,
-    title: 'Corporate Family Friendly',
-    description:
-      'Flexible timings that work with busy professional families. Evening and weekend options.',
-  },
-]
-
-export default function NeetCoachingThanePage() {
-  const handleWhatsAppClick = () => {
-    if (typeof window !== 'undefined' && (window as any).gtag) {
-      ;(window as any).gtag('event', 'whatsapp_click', {
-        event_category: 'conversion',
-        event_label: 'thane_neet_page',
-      })
-    }
-    window.open(`https://wa.me/${WHATSAPP_NUMBER}?text=${WHATSAPP_MESSAGE}`, '_blank')
-  }
-
+export default function NEETCoachingThaneMumbaiPage() {
   return (
-    <div className="min-h-screen">
-      <CitySchema
-        cityName="Thane"
-        citySlug="thane-mumbai"
-        state="Maharashtra"
-        localities={localities.map((l) => l.name)}
-        faqs={faqs}
-        studentCount="920"
-        coordinates={{ lat: '19.2183', lng: '72.9781' }}
+    <>
+      <LocalitySchema
+        locality="Thane"
+        slug="neet-coaching-thane-mumbai"
+        pageTitle="Best NEET Coaching in Thane"
+        pageDescription="Join #1 NEET coaching in Thane. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
       />
-
-      {/* Hero Section */}
-      <section className="relative bg-gradient-to-br from-[#1e3a5f] via-[#2d5a87] to-[#3d7ab5] text-white py-20 overflow-hidden">
-        <div className="absolute inset-0 bg-black/10" />
-        <div className="relative max-w-7xl mx-auto px-4">
-          <motion.div
-            className="text-center max-w-4xl mx-auto"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-          >
-            <div className="inline-flex items-center bg-white/20 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
-              <MapPin className="w-5 h-5 mr-2" />
-              City of Lakes | Premium NEET Coaching
-            </div>
-            <h1 className="text-4xl md:text-6xl font-bold mb-6">
-              Best <span className="text-[#4ade80]">NEET Coaching in Thane</span>, Mumbai
-            </h1>
-            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
-              Thane West | Ghodbunder Road | Hiranandani | Majiwada | Naupada
-            </h2>
-            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
-              Premium NEET Biology coaching for Thane&apos;s best schools. 94.2% success rate, AIIMS
-              faculty, zero Mumbai traffic. Join 920+ students from Hiranandani Foundation, DAV,
-              Singhania!
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-8">
-              <Button
-                variant="secondary"
-                size="xl"
-                onClick={handleWhatsAppClick}
-                className="bg-[#25D366] text-white hover:bg-[#20BD5A] flex items-center justify-center gap-2"
-              >
-                <MessageCircle className="w-6 h-6" />
-                <span>WhatsApp Us Now</span>
-              </Button>
-              <Link href="/demo-booking">
-                <Button
-                  variant="secondary"
-                  size="xl"
-                  className="bg-[#4ade80] text-[#1e3a5f] hover:bg-[#22c55e]"
-                >
-                  <Play className="w-5 h-5 mr-2" />
-                  Book Free Demo Class
-                </Button>
-              </Link>
-            </div>
-            <div className="flex items-center justify-center gap-2 text-white/90 mb-12">
-              <Phone className="w-5 h-5" />
-              <span>Call: </span>
-              <a href="tel:+918826444334" className="font-bold hover:text-[#4ade80]">
-                +91-88264-44334
-              </a>
-            </div>
-            <div className="grid md:grid-cols-4 gap-6 max-w-4xl mx-auto">
-              {successMetrics.map((metric, index) => (
-                <motion.div
-                  key={metric.label}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: 0.2 + index * 0.1 }}
-                  className="bg-white/10 backdrop-blur-sm rounded-xl p-6"
-                >
-                  <metric.icon className="w-8 h-8 mx-auto mb-2 text-[#4ade80]" />
-                  <div className="text-2xl font-bold">{metric.value}</div>
-                  <div className="text-sm opacity-80">{metric.label}</div>
-                </motion.div>
-              ))}
-            </div>
-          </motion.div>
-        </div>
-      </section>
-
-      {/* NEET Tools Section */}
-      <section className="py-12 bg-gradient-to-r from-[#1e3a5f] to-[#2d5a87] text-white">
-        <div className="max-w-7xl mx-auto px-4">
-          <div className="text-center mb-8">
-            <h2 className="text-2xl md:text-3xl font-bold mb-2">Free NEET Preparation Tools</h2>
-          </div>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            {neetTools.map((tool) => (
-              <Link
-                key={tool.name}
-                href={tool.href}
-                className="bg-white/10 hover:bg-white/20 backdrop-blur-sm rounded-xl p-4 text-center transition-all hover:scale-105"
-              >
-                <tool.icon className="w-8 h-8 mx-auto mb-2" />
-                <span className="text-sm font-medium">{tool.name}</span>
-              </Link>
-            ))}
-          </div>
-          <div className="text-center mt-6">
-            <Link href="/neet-tools">
-              <Button
-                variant="outline"
-                className="border-white text-white hover:bg-white hover:text-[#1e3a5f]"
-              >
-                View All NEET Tools <ArrowRight className="w-4 h-4 ml-2" />
-              </Button>
-            </Link>
-          </div>
-        </div>
-      </section>
-
-      {/* Localities Section */}
-      <section className="py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div className="text-center mb-16">
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              NEET Coaching Across Thane District
-            </h2>
-          </motion.div>
-          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {localities.map((locality, index) => (
-              <motion.div
-                key={locality.name}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.05 }}
-                viewport={{ once: true }}
-              >
-                <div
-                  className={`bg-white rounded-xl shadow-lg p-6 hover:shadow-xl transition-all hover:-translate-y-1 ${locality.priority === 'high' ? 'ring-2 ring-[#1e3a5f]' : ''}`}
-                >
-                  <div className="flex items-center justify-between mb-2">
-                    <h3 className="text-lg font-bold text-gray-900">{locality.name}</h3>
-                    <MapPin className="w-5 h-5 text-[#1e3a5f]" />
-                  </div>
-                  <div className="text-2xl font-bold text-[#1e3a5f] mb-1">{locality.students}</div>
-                  <div className="text-sm text-gray-500">{locality.highlight}</div>
-                </div>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Why Thane Section */}
-      <section className="py-20 bg-white">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div className="text-center mb-16">
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              Why Thane Families Choose Cerebrum
-            </h2>
-          </motion.div>
-          <div className="grid md:grid-cols-3 gap-8 mb-16">
-            {whyThane.map((item, index) => (
-              <motion.div
-                key={item.title}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-gray-50 rounded-xl p-8 border border-gray-200"
-              >
-                <item.icon className="w-12 h-12 text-[#1e3a5f] mb-4" />
-                <h3 className="text-xl font-bold text-gray-900 mb-2">{item.title}</h3>
-                <p className="text-gray-600">{item.description}</p>
-              </motion.div>
-            ))}
-          </div>
-          <div className="bg-gray-50 rounded-2xl p-8">
-            <h3 className="text-2xl font-bold text-gray-900 mb-6 text-center">
-              Students from These Thane Schools Trust Us
-            </h3>
-            <div className="flex flex-wrap justify-center gap-4">
-              {premiumSchools.map((school) => (
-                <span
-                  key={school}
-                  className="bg-white text-gray-700 px-4 py-2 rounded-full font-medium shadow-sm"
-                >
-                  {school}
-                </span>
-              ))}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Features Section */}
-      <section className="py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div className="text-center mb-16">
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              Premium NEET Biology Coaching Features
-            </h2>
-          </motion.div>
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {features.map((feature, index) => (
-              <motion.div
-                key={feature.title}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-white rounded-xl p-8 shadow-lg"
-              >
-                <feature.icon className="w-12 h-12 text-[#1e3a5f] mb-4" />
-                <h3 className="text-xl font-bold text-gray-900 mb-2">{feature.title}</h3>
-                <p className="text-gray-600">{feature.description}</p>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <VideoTestimonialsSection />
-
-      {/* FAQs Section */}
-      <section className="py-20 bg-white">
-        <div className="max-w-4xl mx-auto px-4">
-          <motion.div className="text-center mb-16">
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              FAQs - NEET Coaching Thane
-            </h2>
-          </motion.div>
-          <div className="space-y-6">
-            {faqs.map((faq, index) => (
-              <motion.div
-                key={faq.question}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-gray-50 rounded-xl p-8"
-                itemScope
-                itemType="https://schema.org/Question"
-              >
-                <h3
-                  className="text-xl font-bold text-gray-900 mb-4 flex items-start"
-                  itemProp="name"
-                >
-                  <MessageCircle className="w-6 h-6 mr-3 text-[#1e3a5f] flex-shrink-0 mt-1" />
-                  {faq.question}
-                </h3>
-                <div itemScope itemType="https://schema.org/Answer" itemProp="acceptedAnswer">
-                  <p className="text-gray-700 leading-relaxed ml-9" itemProp="text">
-                    {faq.answer}
-                  </p>
-                </div>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Final CTA Section */}
-      <section className="py-20 bg-gradient-to-r from-[#1e3a5f] via-[#2d5a87] to-[#3d7ab5] text-white">
-        <div className="max-w-4xl mx-auto px-4 text-center">
-          <motion.div initial={{ opacity: 0, y: 20 }} whileInView={{ opacity: 1, y: 0 }}>
-            <h2 className="text-3xl md:text-5xl font-bold mb-6">
-              Join Thane&apos;s Elite NEET Aspirants
-            </h2>
-            <p className="text-xl md:text-2xl mb-8 opacity-90">
-              94.2% success rate, AIIMS faculty, premium small batches. No Mumbai commute needed!
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-8">
-              <Button
-                variant="secondary"
-                size="xl"
-                onClick={handleWhatsAppClick}
-                className="bg-[#25D366] text-white hover:bg-[#20BD5A] flex items-center justify-center gap-2"
-              >
-                <MessageCircle className="w-6 h-6" />
-                <span>WhatsApp Us Now</span>
-              </Button>
-              <Link href="/demo-booking">
-                <Button
-                  variant="secondary"
-                  size="xl"
-                  className="bg-white text-[#1e3a5f] hover:bg-gray-100"
-                >
-                  <Play className="w-5 h-5 mr-2" />
-                  Book Free Demo Class
-                </Button>
-              </Link>
-            </div>
-            <div className="flex items-center justify-center gap-2 text-white/90">
-              <Phone className="w-5 h-5" />
-              <span>Call: </span>
-              <a href="tel:+918826444334" className="font-bold hover:text-[#4ade80]">
-                +91-88264-44334
-              </a>
-            </div>
-          </motion.div>
-        </div>
-      </section>
-    </div>
+      <PageContent />
+    </>
   )
 }

--- a/src/app/neet-coaching-vaishali-nagar-jaipur/PageContent.tsx
+++ b/src/app/neet-coaching-vaishali-nagar-jaipur/PageContent.tsx
@@ -1,0 +1,163 @@
+'use client'
+import { useState, useEffect, useRef } from 'react'
+import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield } from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        setIsVisible(true)
+        observer.unobserve(element)
+      }
+    }, { threshold })
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+  return { ref, isVisible }
+}
+
+const areas = [
+  { name: 'Vaishali Nagar', distance: '0 km', landmark: 'Premium Residential' },
+  { name: 'Vaishali Nagar', distance: '3 km', landmark: 'Educational Hub' },
+  { name: 'C-Scheme', distance: '4 km', landmark: 'Tier 1 Premium' },
+  { name: 'Bani Park', distance: '5 km', landmark: 'Heritage Area' },
+  { name: 'MI Road', distance: '6 km', landmark: 'Central Business' },
+  { name: 'Adarsh Nagar', distance: '4 km', landmark: 'Residential Zone' },
+  { name: 'Jawahar Lal Nehru Marg', distance: '7 km', landmark: 'Premium Area' },
+  { name: 'Raja Park', distance: '8 km', landmark: 'Upscale Locality' },
+]
+
+const whyChooseUs = [
+  { icon: Building, title: 'Vaishali Nagar Professional Families Trust Us', description: 'Top choice for Vaishali Nagar professionals and academics. Trusted by doctors, engineers, and business families.' },
+  { icon: Target, title: '500+ NEET Selections', description: 'Proven success with students from premier Jaipur institutions.' },
+  { icon: GraduationCap, title: 'Expert Medical Faculty', description: 'NEET biology coaching by experienced medical professionals with 15+ years expertise.' },
+  { icon: Star, title: 'Top NEET Results', description: 'Vaishali Nagar students achieve 685+ NEET scores consistently.' },
+]
+
+const faqs = [
+  { question: 'Why do Vaishali Nagar families choose your NEET coaching?', answer: 'Vaishali Nagar families value quality and results. We provide premium online NEET coaching with expert faculty and proven 98% success rate.' },
+  { question: 'Do you have classes in Vaishali Nagar?', answer: 'Our NEET coaching is delivered through premium online live classes. Flexibility suits busy Vaishali Nagar professionals perfectly.' },
+  { question: 'Which schools do your students come from?', answer: 'We coach students from premier Jaipur institutions serving Vaishali Nagar and surrounding areas.' },
+  { question: 'How personalized is your coaching?', answer: 'Each student receives personalized attention with customized study plans and one-on-one doubt clearing sessions.' },
+]
+
+const faqSchema = { '@context': 'https://schema.org', '@type': 'FAQPage', mainEntity: faqs.map((faq) => ({ '@type': 'Question', name: faq.question, acceptedAnswer: { '@type': 'Answer', text: faq.answer } })) }
+const localBusinessSchema = { '@context': 'https://schema.org', '@type': 'LocalBusiness', name: 'Cerebrum Biology Academy - NEET Coaching Vaishali Nagar', description: 'Best NEET Coaching for Vaishali Nagar Jaipur', url: 'https://cerebrumbiologyacademy.com/neet-coaching-vaishali-nagar-jaipur', telephone: '+91-88264-44334', address: { '@type': 'PostalAddress', addressLocality: 'Jaipur', addressRegion: 'Rajasthan', addressCountry: 'IN' }, areaServed: ['Vaishali Nagar', 'Vaishali Nagar', 'C-Scheme', 'Jaipur'], priceRange: '$$' }
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }} />
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div ref={heroAnim.ref} className={`text-center max-w-4xl mx-auto transition-all duration-700 ${heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Building className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Professional Families | Expert Faculty
+            </div>
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">NEET Coaching in <span className="text-yellow-400">Vaishali Nagar Jaipur</span></h1>
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">Premium NEET Coaching for Professional Excellence</h2>
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">Expert NEET coaching for Vaishali Nagar and surrounding premium areas. Learn from accomplished medical faculty trusted by <strong>professionals and academic families</strong>. Premium online classes with proven 685+ NEET results.</p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking"><Button variant="secondary" size="xl" className="bg-yellow-500 text-black hover:bg-yellow-400"><Play className="w-5 h-5 mr-2" />Book Free Demo</Button></Link>
+              <a href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Malviya%20Nagar%20Jaipur%20and%20interested%20in%20NEET%20coaching" target="_blank" rel="noopener noreferrer"><Button variant="outline" size="xl" className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"><MessageCircle className="w-5 h-5 mr-2" />WhatsApp</Button></a>
+              <a href="tel:+918826444334"><Button variant="outline" size="xl" className="border-white text-white hover:bg-white hover:text-slate-900"><Headphones className="w-5 h-5 mr-2" />Call Now</Button></a>
+            </div>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6"><Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" /><div className="text-2xl font-bold">500+</div><div className="text-sm opacity-80">NEET Selections</div></div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6"><Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" /><div className="text-2xl font-bold">Premium</div><div className="text-sm opacity-80">Residential</div></div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6"><Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" /><div className="text-2xl font-bold">15+</div><div className="text-sm opacity-80">Years Experience</div></div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6"><Star className="w-8 h-8 mx-auto mb-2 text-yellow-400" /><div className="text-2xl font-bold">685+</div><div className="text-sm opacity-80">Top Score</div></div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div ref={areasHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">Vaishali Nagar & Premium Jaipur Areas</h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">Online NEET coaching for Jaipur's premium residential zones</p>
+          </div>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {areas.map((area, index) => (
+              <div key={area.name} className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up" style={{ animationDelay: `${index * 50}ms` }}>
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div ref={whyHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">Why Vaishali Nagar Families Choose Us</h2>
+          </div>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div key={item.title} className="text-center animate-fade-in-up" style={{ animationDelay: `${index * 100}ms` }}>
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6"><item.icon className="w-8 h-8 text-white" /></div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div ref={faqsHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div key={faq.question} className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up" style={{ animationDelay: `${index * 100}ms` }}>
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start"><MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />{faq.question}</h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div ref={ctaAnim.ref} className={`transition-all duration-600 ${ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">Vaishali Nagar Students, Ace NEET!</h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">Premium NEET coaching for Vaishali Nagar's finest families</p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking"><Button variant="secondary" size="xl" className="bg-yellow-500 text-black hover:bg-yellow-400"><Play className="w-5 h-5 mr-2" />Book Free Demo</Button></Link>
+              <a href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Malviya%20Nagar%20Jaipur%20and%20interested%20in%20NEET%20coaching" target="_blank" rel="noopener noreferrer"><Button variant="outline" size="xl" className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"><MessageCircle className="w-5 h-5 mr-2" />WhatsApp Us</Button></a>
+              <a href="tel:+918826444334"><Button variant="outline" size="xl" className="border-white text-white hover:bg-white hover:text-slate-800"><Headphones className="w-5 h-5 mr-2" />Call: +91-88264-44334</Button></a>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link href="/neet-coaching-jaipur" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">Jaipur NEET Hub</Link>
+            <Link href="/neet-coaching-c-scheme-jaipur" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">C-Scheme Coaching</Link>
+            <Link href="/neet-biology-tutor-online" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">Online Classes</Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-vaishali-nagar-jaipur/page.tsx
+++ b/src/app/neet-coaching-vaishali-nagar-jaipur/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Vaishali Nagar'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Vaishali Nagar Jaipur | Education Hub | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Vaishali Nagar, Jaipur. Expert faculty, proven 98% success rate, 695/720 top score. Premium coaching for educational families. Book free demo!',
+  keywords: [
+    'NEET coaching Vaishali Nagar',
+    'biology tuition Vaishali Nagar Jaipur',
+    'NEET classes Vaishali Nagar',
+    'best NEET tutor Jaipur',
+    'medical entrance education hub',
+    'NEET preparation Vaishali Nagar',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Vaishali Nagar Jaipur | Education Hub | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Vaishali Nagar, Jaipur. Expert faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-vaishali-nagar-jaipur`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Vaishali Nagar Jaipur | Education Hub',
+    description:
+      'Join #1 NEET coaching in Vaishali Nagar, Jaipur. Expert faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-vaishali-nagar-jaipur`,
+  },
+}
+
+export default function NEETCoachingVaishaliNagarJaipurPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Vaishali Nagar"
+        slug="neet-coaching-vaishali-nagar-jaipur"
+        pageTitle="Best NEET Coaching in Vaishali Nagar"
+        pageDescription="Join #1 NEET coaching in Vaishali Nagar, Jaipur. Expert faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-velachery-chennai/PageContent.tsx
+++ b/src/app/neet-coaching-velachery-chennai/PageContent.tsx
@@ -1,0 +1,402 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  MapPin,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const velacheryAreas = [
+{ name: 'Velachery', distance: '14 km', landmark: 'IT Corridor' },
+  { name: 'VGP Golden Plaza', distance: '15 km', landmark: 'Commercial Hub' },
+  { name: 'Phoenix Mall Area', distance: '16 km', landmark: 'Retail Zone' },
+  { name: 'Tharamani', distance: '13 km', landmark: 'IT Zone' },
+  { name: 'Navalur', distance: '17 km', landmark: 'IT Park' },
+  { name: 'Selaiyur', distance: '18 km', landmark: 'Residential' },
+  { name: 'Kottivakkam', distance: '19 km', landmark: 'Mixed Use' },
+  { name: 'Tambaram', distance: '20 km', landmark: 'Business Zone' }
+]
+
+const whyChooseUs = [
+
+]
+
+const faqs = [
+{
+    question: 'Why Velachery IT families choose online NEET coaching?',
+    answer:
+      'Velachery IT professionals value efficiency and technology. Online NEET coaching offers flexibility, modern tools, and data-driven learning. High internet connectivity and tech-savvy mindset make online perfect.',
+  },
+  {
+    question: 'How do you support IT professional schedules?',
+    answer:
+      'IT professionals have demanding, variable schedules. Flexible classes, recorded lectures, catch-up sessions, and asynchronous content ensure learning continuity despite work demands.',
+  },
+  {
+    question: 'What schools do Velachery students attend?',
+    answer:
+      'We have students from Chettinad Vidyashram, Padma Seshadri, Sri Aurobindo International, and tech-focused schools. Velachery attracts educated IT families.',
+  },
+  {
+    question: 'How does your platform leverage technology?',
+    answer:
+      'AI-powered learning analytics, real-time dashboards, mobile apps, and automated doubt resolution. IT families appreciate technology-driven education.',
+  }
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Velachery',
+  description: 'Best NEET Coaching for Velachery Chennai - Trusted by Premium Families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-velachery-chennai',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Velachery', 'VGP Golden Plaza', 'Phoenix Mall Area', 'Tharamani', 'Navalur'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ { __html: JSON.stringify(faqSchema) } }
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={ { __html: JSON.stringify(localBusinessSchema) } }
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <MapPin className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by IT & Corporate Families
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Velachery</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              IT Corridor & VGP Layout
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Premium NEET coaching for Velachery, VGP layout, Phoenix Mall area & nearby tech families. Learn from Dr. Shekhar C Singh, AIIMS Alumnus - trusted by IT professionals.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Velachery%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <MapPin className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Online</div>
+                <div className="text-sm opacity-80">Classes</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">680+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Velachery & Nearby Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Chennai premium families
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {velacheryAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={ { animationDelay: `${index * 50}ms` } }
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Velachery Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={ { animationDelay: `${index * 100}ms` } }
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={ { animationDelay: `${index * 100}ms` } }
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Velachery Students, Crack NEET!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium coaching for IT families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Velachery%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-chennai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Chennai NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-t-nagar-chennai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              T Nagar Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-velachery-chennai/page.tsx
+++ b/src/app/neet-coaching-velachery-chennai/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Velachery'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Velachery | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Velachery Chennai. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Personalized batches & doubt clearing. Book free demo!',
+  keywords: [
+    'NEET coaching Velachery',
+    'biology tuition Velachery',
+    'NEET classes Velachery Chennai',
+    'best NEET tutor Velachery',
+    'medical entrance coaching Velachery',
+    'NEET preparation Chennai',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Velachery | 98% Success Rate | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Velachery Chennai. Expert AIIMS faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-velachery-chennai`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Velachery | 98% Success Rate',
+    description:
+      'Join #1 NEET coaching in Velachery Chennai. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-velachery-chennai`,
+  },
+}
+
+export default function NEETCoachingVelacheryPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Velachery"
+        slug="neet-coaching-velachery-chennai"
+        pageTitle="Best NEET Coaching in Velachery"
+        pageDescription="Join #1 NEET coaching in Velachery Chennai. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-versova-mumbai/PageContent.tsx
+++ b/src/app/neet-coaching-versova-mumbai/PageContent.tsx
@@ -1,0 +1,427 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Gem,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const versovaAreas = [
+  { name: 'Versova', distance: '16 km', landmark: 'West Coastal Area' },
+  { name: 'Andheri West', distance: '15 km', landmark: 'Film City Adjacent' },
+  { name: 'Four Bungalows', distance: '14 km', landmark: 'Premium Residential' },
+  { name: 'Lokhandwala', distance: '15 km', landmark: 'Complex Residential' },
+  { name: 'Kala Ghoda', distance: '14 km', landmark: 'Andheri East' },
+  { name: 'Link Road', distance: '16 km', landmark: 'Shopping Hub' },
+  { name: 'Andheri East', distance: '17 km', landmark: 'IT & Corporate' },
+  { name: 'Oshiwara', distance: '13 km', landmark: 'Premium Locality' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Gem,
+    title: 'Andheri West Expertise',
+    description:
+      'Specialized coaching for Versova, Four Bungalows, and premium Andheri West residential areas. We understand the unique dynamics of these prestigious localities.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Proven track record with students from top schools including Cathedral School, Bombay Scottish, Jamnabai Narsee in the Andheri area.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'AIIMS Faculty',
+    description:
+      'Dr. Shekhar C Singh, AIIMS Alumnus with 15+ years experience coaching motivated students from premium Andheri localities.',
+  },
+  {
+    icon: Star,
+    title: 'Top Results',
+    description:
+      'Versova & Four Bungalows students scored 685+ in NEET with AIIMS and top medical college admissions.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Do you have a coaching center in Versova or Andheri?',
+    answer:
+      'Our main center is in Greater Noida. For Versova and Andheri West students, we offer premium live online NEET classes. Many families in these premium localities prefer online coaching for flexibility. Our comprehensive material and recorded lectures ensure continuous preparation.',
+  },
+  {
+    question: 'How is your coaching suitable for Andheri West families?',
+    answer:
+      'Andheri West residents value quality, exclusivity, and results. We offer structured schedules, one-on-one guidance, detailed progress reports, and result-oriented teaching. Many students from Four Bungalows and premium Andheri complexes have achieved top NEET ranks with us.',
+  },
+  {
+    question: 'Which schools do your Versova and Andheri students attend?',
+    answer:
+      'We have students from Cathedral School Mumbai, Bombay Scottish, Jamnabai Narsee, Ecole Mondiale, and other top institutions in Andheri West and nearby premium areas. These schools\' rigorous academics align perfectly with our NEET preparation.',
+  },
+  {
+    question: 'How do you support working parents in Andheri?',
+    answer:
+      'Many Andheri West families are busy professionals. Our flexible online platform accommodates irregular schedules. Students can attend live classes when available and use recorded lectures during busy times. Detailed progress reports keep parents informed without requiring their constant involvement.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Versova',
+  description: 'Best NEET Coaching for Versova & Andheri West - Premium coaching for premium families',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-versova-mumbai',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Versova', 'Andheri West', 'Four Bungalows', 'Lokhandwala', 'Oshiwara'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
+      />
+
+      {/* Hero */}
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div
+            ref={heroAnim.ref}
+            className={`text-center max-w-4xl mx-auto transition-all duration-700 ${
+              heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Gem className="w-5 h-5 mr-2 text-yellow-400" />
+              Premium Andheri West Coaching | AIIMS Faculty
+            </div>
+
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Versova</span>
+            </h1>
+
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Best Biology Coaching for Andheri West&apos;s Premium Localities
+            </h2>
+
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Exclusive NEET coaching for Versova, Four Bungalows, Lokhandwala, and Andheri West.
+              Learn from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by premium
+              Andheri families.
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Versova%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-900"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Gem className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Premium</div>
+                <div className="text-sm opacity-80">Localities</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">685+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Areas Covered */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={areasHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Versova & Andheri West Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for premium Andheri West and surrounding residential areas
+            </p>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {versovaAreas.map((area, index) => (
+              <div
+                key={area.name}
+                className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
+                style={{ animationDelay: `${index * 50}ms` }}
+              >
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Why Choose Us */}
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div
+            ref={whyHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Versova & Andheri Families Choose Us
+            </h2>
+          </div>
+
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div
+                key={item.title}
+                className="text-center animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQs */}
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div
+            ref={faqsHeaderAnim.ref}
+            className={`text-center mb-16 transition-all duration-600 ${
+              faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div
+                key={faq.question}
+                className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
+                style={{ animationDelay: `${index * 100}ms` }}
+              >
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA */}
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div
+            ref={ctaAnim.ref}
+            className={`transition-all duration-600 ${
+              ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'
+            }`}
+          >
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Versova Students, Crack NEET with Confidence!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium NEET coaching for premium Andheri West families
+            </p>
+
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button
+                  variant="secondary"
+                  size="xl"
+                  className="bg-yellow-500 text-black hover:bg-yellow-400"
+                >
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+
+              <a
+                href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Versova%20and%20interested%20in%20NEET%20coaching"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"
+                >
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+
+              <a href="tel:+918826444334">
+                <Button
+                  variant="outline"
+                  size="xl"
+                  className="border-white text-white hover:bg-white hover:text-slate-800"
+                >
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Related */}
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/neet-coaching-mumbai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Mumbai NEET Hub
+            </Link>
+            <Link
+              href="/neet-coaching-andheri-mumbai"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Andheri NEET Coaching
+            </Link>
+            <Link
+              href="/neet-biology-tutor-online"
+              className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition"
+            >
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-versova-mumbai/page.tsx
+++ b/src/app/neet-coaching-versova-mumbai/page.tsx
@@ -1,0 +1,69 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Versova'
+const city = 'Mumbai'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: `${locality}, ${city}`,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Versova Mumbai | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Versova, Andheri West. Expert AIIMS faculty, 98% success rate. Four Bungalows, Lokhandwala area. Book free demo!',
+  keywords: [
+    'NEET coaching Versova',
+    'biology tuition Versova',
+    'NEET classes Andheri West',
+    'best NEET tutor Four Bungalows',
+    'medical entrance Lokhandwala',
+    'NEET preparation Versova',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Versova Mumbai | 98% Success Rate | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Versova, Andheri West. Expert AIIMS faculty, 98% success rate. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-versova-mumbai`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Versova Mumbai | 98% Success Rate',
+    description:
+      'Join #1 NEET coaching in Versova, Andheri West. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-versova-mumbai`,
+  },
+}
+
+export default function NEETCoachingVersovaMumbaiPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Versova"
+        slug="neet-coaching-versova-mumbai"
+        pageTitle="Best NEET Coaching in Versova"
+        pageDescription="Join #1 NEET coaching in Versova, Andheri West. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/app/neet-coaching-viman-nagar-pune/PageContent.tsx
+++ b/src/app/neet-coaching-viman-nagar-pune/PageContent.tsx
@@ -1,0 +1,322 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import {
+  Trophy,
+  Users,
+  MessageCircle,
+  Play,
+  Headphones,
+  MapPin,
+  Star,
+  GraduationCap,
+  Target,
+  Building,
+  Gem,
+} from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true)
+          observer.unobserve(element)
+        }
+      },
+      { threshold }
+    )
+
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+
+  return { ref, isVisible }
+}
+
+const vimanAreas = [
+  { name: 'Viman Nagar', distance: '9 km', landmark: 'Airport Road Adjacent' },
+  { name: 'Phoenix Market City', distance: '9 km', landmark: 'Shopping Hub' },
+  { name: 'Sundale', distance: '8 km', landmark: 'Premium Residential' },
+  { name: 'Kharadi', distance: '10 km', landmark: 'Commercial Area' },
+  { name: 'Magarpatta', distance: '11 km', landmark: 'Tech City' },
+  { name: 'Hadapsar', distance: '12 km', landmark: 'Industrial Area' },
+  { name: 'Koregaon Park', distance: '7 km', landmark: 'Premium Locality' },
+  { name: 'Aundh', distance: '6 km', landmark: 'Upscale Area' },
+]
+
+const whyChooseUs = [
+  {
+    icon: Gem,
+    title: 'Airport Road Specialist',
+    description:
+      'Viman Nagar is Pune\'s most upscale locality adjacent to the airport. We specialize in coaching for premium families and highly ambitious students.',
+  },
+  {
+    icon: Target,
+    title: '500+ NEET Selections',
+    description:
+      'Proven track record with students from elite institutions across Viman Nagar and Koregaon Park.',
+  },
+  {
+    icon: GraduationCap,
+    title: 'AIIMS Faculty',
+    description:
+      'Dr. Shekhar C Singh, AIIMS Alumnus with 15+ years experience coaching high-achievers from premium families.',
+  },
+  {
+    icon: Star,
+    title: 'Top Results',
+    description:
+      'Viman Nagar students scored 690+ in NEET with multiple AIIMS and prestigious medical college admissions.',
+  },
+]
+
+const faqs = [
+  {
+    question: 'Do you have a coaching center in Viman Nagar?',
+    answer:
+      'Our main center is in Greater Noida. For Viman Nagar residents, we offer premium live online NEET classes. Many upscale families prefer online coaching for convenience. Our comprehensive material and recorded lectures ensure continuous preparation.',
+  },
+  {
+    question: 'How do you cater to Viman Nagar premium families?',
+    answer:
+      'Viman Nagar represents Pune\'s premium lifestyle. We offer exclusive personalized attention, flexible schedules, detailed progress reports, and result-oriented teaching tailored for high-achieving families.',
+  },
+  {
+    question: 'Which schools do your Viman Nagar students attend?',
+    answer:
+      'We have students from Cathedral School, Symbiosis, Jamnabai Narsee, and other elite Pune schools. These academically excellent institutions align perfectly with our NEET preparation.',
+  },
+  {
+    question: 'Is online coaching suitable for globally connected families?',
+    answer:
+      'Absolutely! Many Viman Nagar families travel internationally. Our flexible online platform accommodates global schedules with live classes and recorded sessions for continuity.',
+  },
+]
+
+const faqSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: faqs.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: { '@type': 'Answer', text: faq.answer },
+  })),
+}
+
+const localBusinessSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'LocalBusiness',
+  name: 'Cerebrum Biology Academy - NEET Coaching Viman Nagar',
+  description: 'Best NEET Coaching for Viman Nagar - Premium upscale coaching',
+  url: 'https://cerebrumbiologyacademy.com/neet-coaching-viman-nagar-pune',
+  telephone: '+91-88264-44334',
+  address: {
+    '@type': 'PostalAddress',
+    addressLocality: 'Greater Noida',
+    addressRegion: 'Uttar Pradesh',
+    addressCountry: 'IN',
+  },
+  areaServed: ['Viman Nagar', 'Phoenix Market City', 'Koregaon Park', 'Hadapsar'],
+  priceRange: '$$',
+}
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }} />
+
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div ref={heroAnim.ref} className={`text-center max-w-4xl mx-auto transition-all duration-700 ${heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Gem className="w-5 h-5 mr-2 text-yellow-400" />
+              Premium Airport Road Coaching | AIIMS Faculty
+            </div>
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">
+              NEET Coaching in <span className="text-yellow-400">Viman Nagar</span>
+            </h1>
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
+              Exclusive Biology Coaching for Pune&apos;s Most Upscale Locality
+            </h2>
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
+              Premium NEET coaching for Viman Nagar and Airport Road area residents. Learn from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by Viman Nagar&apos;s elite families.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking">
+                <Button variant="secondary" size="xl" className="bg-yellow-500 text-black hover:bg-yellow-400">
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+              <a href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Viman%20Nagar%20and%20interested%20in%20NEET%20coaching" target="_blank" rel="noopener noreferrer">
+                <Button variant="outline" size="xl" className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500">
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp
+                </Button>
+              </a>
+              <a href="tel:+918826444334">
+                <Button variant="outline" size="xl" className="border-white text-white hover:bg-white hover:text-slate-900">
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call Now
+                </Button>
+              </a>
+            </div>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">500+</div>
+                <div className="text-sm opacity-80">NEET Selections</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Gem className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">Premium</div>
+                <div className="text-sm opacity-80">Upscale</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">15+</div>
+                <div className="text-sm opacity-80">Years Experience</div>
+              </div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6">
+                <Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" />
+                <div className="text-2xl font-bold">690+</div>
+                <div className="text-sm opacity-80">Top Score</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div ref={areasHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Viman Nagar & Surrounding Areas
+            </h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
+              Online NEET coaching for Pune&apos;s premium upscale communities
+            </p>
+          </div>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {vimanAreas.map((area, index) => (
+              <div key={area.name} className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up" style={{ animationDelay: `${index * 50}ms` }}>
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div ref={whyHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
+              Why Viman Nagar Families Choose Us
+            </h2>
+          </div>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div key={item.title} className="text-center animate-fade-in-up" style={{ animationDelay: `${index * 100}ms` }}>
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                  <item.icon className="w-8 h-8 text-white" />
+                </div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div ref={faqsHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div key={faq.question} className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up" style={{ animationDelay: `${index * 100}ms` }}>
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
+                  <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />
+                  {faq.question}
+                </h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div ref={ctaAnim.ref} className={`transition-all duration-600 ${ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">
+              Viman Nagar Students, Crack NEET!
+            </h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">
+              Premium NEET coaching for Pune&apos;s most upscale locality
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking">
+                <Button variant="secondary" size="xl" className="bg-yellow-500 text-black hover:bg-yellow-400">
+                  <Play className="w-5 h-5 mr-2" />
+                  Book Free Demo
+                </Button>
+              </Link>
+              <a href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Viman%20Nagar%20and%20interested%20in%20NEET%20coaching" target="_blank" rel="noopener noreferrer">
+                <Button variant="outline" size="xl" className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500">
+                  <MessageCircle className="w-5 h-5 mr-2" />
+                  WhatsApp Us
+                </Button>
+              </a>
+              <a href="tel:+918826444334">
+                <Button variant="outline" size="xl" className="border-white text-white hover:bg-white hover:text-slate-800">
+                  <Headphones className="w-5 h-5 mr-2" />
+                  Call: +91-88264-44334
+                </Button>
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link href="/neet-coaching-pune" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">
+              Pune NEET Hub
+            </Link>
+            <Link href="/neet-coaching-kalyani-nagar-pune" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">
+              Kalyani Nagar Coaching
+            </Link>
+            <Link href="/neet-biology-tutor-online" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">
+              Online Classes
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-viman-nagar-pune/page.tsx
+++ b/src/app/neet-coaching-viman-nagar-pune/page.tsx
@@ -1,473 +1,67 @@
-'use client'
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
 
-import { motion } from 'framer-motion'
-import {
-  MapPin,
-  Users,
-  Trophy,
-  Star,
-  Award,
-  BookOpen,
-  Clock,
-  Shield,
-  Video,
-  MessageCircle,
-  Play,
-  ArrowRight,
-  GraduationCap,
-  Building,
-  Phone,
-  Calculator,
-  Target,
-  Sparkles,
-} from 'lucide-react'
-import { Button } from '@/components/ui/Button'
-import Link from 'next/link'
-import { VideoTestimonialsSection } from '@/components/testimonials/VideoTestimonialsSection'
-import { CitySchema } from '@/components/seo/CitySchema'
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Viman Nagar'
+const city = 'Pune'
 
-const WHATSAPP_NUMBER = '918826444334'
-const WHATSAPP_MESSAGE = encodeURIComponent(
-  'Hi! I am interested in NEET coaching in Viman Nagar Pune. Please share details.'
-)
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: `${locality}, ${city}`,
+})
 
-const localities = [
-  { name: 'Viman Nagar', students: '280+', highlight: 'Premium IT Hub', priority: 'high' },
-  { name: 'Kalyani Nagar', students: '220+', highlight: 'Ultra Premium', priority: 'high' },
-  { name: 'Kharadi', students: '190+', highlight: 'EON IT Park', priority: 'high' },
-  { name: 'Wadgaon Sheri', students: '150+', highlight: 'Residential', priority: 'high' },
-  { name: 'Yerawada', students: '130+', highlight: 'Central Pune', priority: 'medium' },
-  { name: 'Dhanori', students: '110+', highlight: 'Growing Fast', priority: 'medium' },
-  { name: 'Lohegaon', students: '95+', highlight: 'Airport Area', priority: 'medium' },
-  { name: 'Vishrantwadi', students: '120+', highlight: 'Defence Area', priority: 'medium' },
-]
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Viman Nagar Pune | 98% Success Rate | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Viman Nagar, Pune. Expert AIIMS faculty, 98% success rate. Airport Road, Phoenix Mall area. Premium online coaching. Book free demo!',
+  keywords: [
+    'NEET coaching Viman Nagar',
+    'biology tuition Viman Nagar',
+    'NEET classes Pune Airport',
+    'best NEET tutor Viman Nagar',
+    'medical entrance Phoenix Mall',
+    'NEET preparation Viman Nagar',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Viman Nagar Pune | 98% Success Rate | Cerebrum',
+    description: 'Join #1 NEET coaching in Viman Nagar, Pune. Expert AIIMS faculty, 98% success rate. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-viman-nagar-pune`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Viman Nagar Pune | 98% Success Rate',
+    description: 'Join #1 NEET coaching in Viman Nagar, Pune. Expert AIIMS faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-viman-nagar-pune`,
+  },
+}
 
-const features = [
-  {
-    icon: Video,
-    title: 'Live Interactive Classes',
-    description:
-      'Premium online coaching - no airport road traffic. World-class teaching from your Viman Nagar home.',
-  },
-  {
-    icon: Users,
-    title: 'Elite Small Batches (10-15)',
-    description: 'Exclusive batches for Viman Nagar students with personalized attention.',
-  },
-  {
-    icon: Award,
-    title: 'AIIMS Trained Faculty',
-    description: 'Expert doctors and teachers from premier medical institutions.',
-  },
-  {
-    icon: BookOpen,
-    title: 'Complete Premium Package',
-    description:
-      'NCERT mastery, advanced materials, unlimited doubt sessions - everything included.',
-  },
-  {
-    icon: Clock,
-    title: 'Flexible Timings',
-    description:
-      'Morning, afternoon, evening batches to complement international school schedules.',
-  },
-  {
-    icon: Shield,
-    title: 'Zero Commute Stress',
-    description: 'No traffic to coaching hubs in FC Road. Learn from your premium residence.',
-  },
-]
-
-const successMetrics = [
-  { label: 'Success Rate', value: '94.2%', icon: Trophy },
-  { label: 'Top Score 2024', value: '358', icon: Star },
-  { label: 'Viman Nagar Students', value: '890+', icon: Users },
-  { label: 'Premium Schools', value: '18+', icon: GraduationCap },
-]
-
-const faqs = [
-  {
-    question: 'Why do Viman Nagar students choose online NEET coaching?',
-    answer:
-      'Viman Nagar has excellent international schools like Symbiosis, Vikhe Patil, and DAIS with demanding schedules. Our online classes offer flexibility that physical coaching in FC Road cannot. Save 2-3 hours daily on Pune traffic. Our 94.2% success rate proves online is equally effective.',
-  },
-  {
-    question: 'Which areas in Viman Nagar do you serve?',
-    answer:
-      'We serve all Viman Nagar localities including Viman Nagar Main, Kalyani Nagar, Kharadi, Wadgaon Sheri, Yerawada, Dhanori, Lohegaon, Vishrantwadi, and all surrounding IT corridor areas. Students from anywhere in East Pune can join our online live classes.',
-  },
-  {
-    question: 'What is the fee for premium NEET coaching in Viman Nagar?',
-    answer:
-      'Our complete NEET Biology course ranges from Rs 24,000 to Rs 68,000 per year depending on the program chosen. This is competitive with Pune coaching centers while offering superior flexibility and smaller batches. EMI options available.',
-  },
-  {
-    question: 'How does this compare to coaching centers in FC Road or Deccan?',
-    answer:
-      'Unlike physical coaching centers where batches have 50-100 students, we limit batches to 10-15 students. This means every doubt gets addressed, every student gets personal attention. Plus, you save hours on Pune traffic daily.',
-  },
-  {
-    question: 'What medical colleges can Viman Nagar students target?',
-    answer:
-      'With proper NEET preparation, Viman Nagar students can target top colleges like BJ Medical College, Armed Forces Medical College (AFMC), Symbiosis Medical College, DY Patil Medical College, and all-India institutes like AIIMS and JIPMER.',
-  },
-  {
-    question: 'Do you understand international school patterns?',
-    answer:
-      'Yes! We have specialized batches for international school students (IB, IGCSE, Cambridge). Our faculty understands how to bridge international curriculum with NEET Biology requirements. Many of our Viman Nagar students are from Symbiosis, Mercedes-Benz International, and DAIS Pune.',
-  },
-]
-
-const premiumSchools = [
-  'Symbiosis International School',
-  'Vikhe Patil Memorial School',
-  'DAIS Pune',
-  'Mercedes-Benz International',
-  'Indus International School',
-  'The Orchid School',
-  'Delhi Public School Pune',
-  'Bishops School Kalyani Nagar',
-  'Euro School Airoli',
-  'Vibgyor High School',
-]
-
-const neetTools = [
-  { name: 'NEET Rank Predictor', href: '/neet-rank-predictor', icon: Calculator },
-  { name: 'College Predictor', href: '/neet-college-predictor', icon: Building },
-  { name: 'Study Plan Generator', href: '/neet-study-plan-generator', icon: Target },
-  { name: 'NEET Exam Countdown', href: '/neet-exam-countdown', icon: Clock },
-]
-
-const whyVimanNagar = [
-  {
-    icon: Sparkles,
-    title: 'Premium Quality, Zero Commute',
-    description:
-      'Get world-class NEET coaching without leaving Viman Nagar. No traffic to FC Road coaching hubs.',
-  },
-  {
-    icon: Building,
-    title: 'International School Expert',
-    description:
-      'We understand IB, IGCSE, Cambridge. Our faculty prepares international school students for NEET.',
-  },
-  {
-    icon: GraduationCap,
-    title: 'IT Family Friendly',
-    description:
-      'Flexible timings that work with busy IT professional families. Evening and weekend options.',
-  },
-]
-
-export default function NeetCoachingVimanNagarPage() {
-  const handleWhatsAppClick = () => {
-    if (typeof window !== 'undefined' && (window as any).gtag) {
-      ;(window as any).gtag('event', 'whatsapp_click', {
-        event_category: 'conversion',
-        event_label: 'vimannagar_neet_page',
-      })
-    }
-    window.open(`https://wa.me/${WHATSAPP_NUMBER}?text=${WHATSAPP_MESSAGE}`, '_blank')
-  }
-
+export default function NEETCoachingVimanNagarPunePage() {
   return (
-    <div className="min-h-screen">
-      <CitySchema
-        cityName="Viman Nagar"
-        citySlug="viman-nagar-pune"
-        state="Maharashtra"
-        localities={localities.map((l) => l.name)}
-        faqs={faqs}
-        studentCount="890"
-        coordinates={{ lat: '18.5679', lng: '73.9143' }}
+    <>
+      <LocalitySchema
+        locality="Viman Nagar"
+        slug="neet-coaching-viman-nagar-pune"
+        pageTitle="Best NEET Coaching in Viman Nagar"
+        pageDescription="Join #1 NEET coaching in Viman Nagar, Pune. Expert AIIMS faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
       />
-
-      {/* Hero Section */}
-      <section className="relative bg-gradient-to-br from-[#1e3a5f] via-[#2d5a87] to-[#3d7ab5] text-white py-20 overflow-hidden">
-        <div className="absolute inset-0 bg-black/10" />
-        <div className="relative max-w-7xl mx-auto px-4">
-          <motion.div
-            className="text-center max-w-4xl mx-auto"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-          >
-            <div className="inline-flex items-center bg-white/20 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
-              <MapPin className="w-5 h-5 mr-2" />
-              Pune IT Corridor | Premium NEET Coaching
-            </div>
-            <h1 className="text-4xl md:text-6xl font-bold mb-6">
-              Best <span className="text-[#4ade80]">NEET Coaching in Viman Nagar</span>, Pune
-            </h1>
-            <h2 className="text-xl md:text-2xl opacity-90 mb-4">
-              Kalyani Nagar | Kharadi | Wadgaon Sheri | Yerawada | Dhanori
-            </h2>
-            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
-              Premium NEET Biology coaching for Viman Nagar&apos;s international schools. 94.2%
-              success rate, AIIMS faculty, zero traffic commute. Join 890+ students from Symbiosis,
-              Vikhe Patil, DAIS!
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-8">
-              <Button
-                variant="secondary"
-                size="xl"
-                onClick={handleWhatsAppClick}
-                className="bg-[#25D366] text-white hover:bg-[#20BD5A] flex items-center justify-center gap-2"
-              >
-                <MessageCircle className="w-6 h-6" />
-                <span>WhatsApp Us Now</span>
-              </Button>
-              <Link href="/demo-booking">
-                <Button
-                  variant="secondary"
-                  size="xl"
-                  className="bg-[#4ade80] text-[#1e3a5f] hover:bg-[#22c55e]"
-                >
-                  <Play className="w-5 h-5 mr-2" />
-                  Book Free Demo Class
-                </Button>
-              </Link>
-            </div>
-            <div className="flex items-center justify-center gap-2 text-white/90 mb-12">
-              <Phone className="w-5 h-5" />
-              <span>Call: </span>
-              <a href="tel:+918826444334" className="font-bold hover:text-[#4ade80]">
-                +91-88264-44334
-              </a>
-            </div>
-            <div className="grid md:grid-cols-4 gap-6 max-w-4xl mx-auto">
-              {successMetrics.map((metric, index) => (
-                <motion.div
-                  key={metric.label}
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ delay: 0.2 + index * 0.1 }}
-                  className="bg-white/10 backdrop-blur-sm rounded-xl p-6"
-                >
-                  <metric.icon className="w-8 h-8 mx-auto mb-2 text-[#4ade80]" />
-                  <div className="text-2xl font-bold">{metric.value}</div>
-                  <div className="text-sm opacity-80">{metric.label}</div>
-                </motion.div>
-              ))}
-            </div>
-          </motion.div>
-        </div>
-      </section>
-
-      {/* NEET Tools Section */}
-      <section className="py-12 bg-gradient-to-r from-[#1e3a5f] to-[#2d5a87] text-white">
-        <div className="max-w-7xl mx-auto px-4">
-          <div className="text-center mb-8">
-            <h2 className="text-2xl md:text-3xl font-bold mb-2">Free NEET Preparation Tools</h2>
-          </div>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            {neetTools.map((tool) => (
-              <Link
-                key={tool.name}
-                href={tool.href}
-                className="bg-white/10 hover:bg-white/20 backdrop-blur-sm rounded-xl p-4 text-center transition-all hover:scale-105"
-              >
-                <tool.icon className="w-8 h-8 mx-auto mb-2" />
-                <span className="text-sm font-medium">{tool.name}</span>
-              </Link>
-            ))}
-          </div>
-          <div className="text-center mt-6">
-            <Link href="/neet-tools">
-              <Button
-                variant="outline"
-                className="border-white text-white hover:bg-white hover:text-[#1e3a5f]"
-              >
-                View All NEET Tools <ArrowRight className="w-4 h-4 ml-2" />
-              </Button>
-            </Link>
-          </div>
-        </div>
-      </section>
-
-      {/* Localities Section */}
-      <section className="py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div className="text-center mb-16">
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              NEET Coaching Across Viman Nagar & East Pune
-            </h2>
-          </motion.div>
-          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {localities.map((locality, index) => (
-              <motion.div
-                key={locality.name}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.05 }}
-                viewport={{ once: true }}
-              >
-                <div
-                  className={`bg-white rounded-xl shadow-lg p-6 hover:shadow-xl transition-all hover:-translate-y-1 ${locality.priority === 'high' ? 'ring-2 ring-[#1e3a5f]' : ''}`}
-                >
-                  <div className="flex items-center justify-between mb-2">
-                    <h3 className="text-lg font-bold text-gray-900">{locality.name}</h3>
-                    <MapPin className="w-5 h-5 text-[#1e3a5f]" />
-                  </div>
-                  <div className="text-2xl font-bold text-[#1e3a5f] mb-1">{locality.students}</div>
-                  <div className="text-sm text-gray-500">{locality.highlight}</div>
-                </div>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Why Viman Nagar Section */}
-      <section className="py-20 bg-white">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div className="text-center mb-16">
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              Why Viman Nagar IT Families Choose Cerebrum
-            </h2>
-          </motion.div>
-          <div className="grid md:grid-cols-3 gap-8 mb-16">
-            {whyVimanNagar.map((item, index) => (
-              <motion.div
-                key={item.title}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-gray-50 rounded-xl p-8 border border-gray-200"
-              >
-                <item.icon className="w-12 h-12 text-[#1e3a5f] mb-4" />
-                <h3 className="text-xl font-bold text-gray-900 mb-2">{item.title}</h3>
-                <p className="text-gray-600">{item.description}</p>
-              </motion.div>
-            ))}
-          </div>
-          <div className="bg-gray-50 rounded-2xl p-8">
-            <h3 className="text-2xl font-bold text-gray-900 mb-6 text-center">
-              Students from These Viman Nagar Schools Trust Us
-            </h3>
-            <div className="flex flex-wrap justify-center gap-4">
-              {premiumSchools.map((school) => (
-                <span
-                  key={school}
-                  className="bg-white text-gray-700 px-4 py-2 rounded-full font-medium shadow-sm"
-                >
-                  {school}
-                </span>
-              ))}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Features Section */}
-      <section className="py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4">
-          <motion.div className="text-center mb-16">
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              Premium NEET Biology Coaching Features
-            </h2>
-          </motion.div>
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {features.map((feature, index) => (
-              <motion.div
-                key={feature.title}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-white rounded-xl p-8 shadow-lg"
-              >
-                <feature.icon className="w-12 h-12 text-[#1e3a5f] mb-4" />
-                <h3 className="text-xl font-bold text-gray-900 mb-2">{feature.title}</h3>
-                <p className="text-gray-600">{feature.description}</p>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <VideoTestimonialsSection />
-
-      {/* FAQs Section */}
-      <section className="py-20 bg-white">
-        <div className="max-w-4xl mx-auto px-4">
-          <motion.div className="text-center mb-16">
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              FAQs - NEET Coaching Viman Nagar
-            </h2>
-          </motion.div>
-          <div className="space-y-6">
-            {faqs.map((faq, index) => (
-              <motion.div
-                key={faq.question}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.1 }}
-                viewport={{ once: true }}
-                className="bg-gray-50 rounded-xl p-8"
-                itemScope
-                itemType="https://schema.org/Question"
-              >
-                <h3
-                  className="text-xl font-bold text-gray-900 mb-4 flex items-start"
-                  itemProp="name"
-                >
-                  <MessageCircle className="w-6 h-6 mr-3 text-[#1e3a5f] flex-shrink-0 mt-1" />
-                  {faq.question}
-                </h3>
-                <div itemScope itemType="https://schema.org/Answer" itemProp="acceptedAnswer">
-                  <p className="text-gray-700 leading-relaxed ml-9" itemProp="text">
-                    {faq.answer}
-                  </p>
-                </div>
-              </motion.div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Final CTA Section */}
-      <section className="py-20 bg-gradient-to-r from-[#1e3a5f] via-[#2d5a87] to-[#3d7ab5] text-white">
-        <div className="max-w-4xl mx-auto px-4 text-center">
-          <motion.div initial={{ opacity: 0, y: 20 }} whileInView={{ opacity: 1, y: 0 }}>
-            <h2 className="text-3xl md:text-5xl font-bold mb-6">
-              Join Viman Nagar&apos;s Elite NEET Aspirants
-            </h2>
-            <p className="text-xl md:text-2xl mb-8 opacity-90">
-              94.2% success rate, AIIMS faculty, premium small batches. International school
-              specialists!
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-8">
-              <Button
-                variant="secondary"
-                size="xl"
-                onClick={handleWhatsAppClick}
-                className="bg-[#25D366] text-white hover:bg-[#20BD5A] flex items-center justify-center gap-2"
-              >
-                <MessageCircle className="w-6 h-6" />
-                <span>WhatsApp Us Now</span>
-              </Button>
-              <Link href="/demo-booking">
-                <Button
-                  variant="secondary"
-                  size="xl"
-                  className="bg-white text-[#1e3a5f] hover:bg-gray-100"
-                >
-                  <Play className="w-5 h-5 mr-2" />
-                  Book Free Demo Class
-                </Button>
-              </Link>
-            </div>
-            <div className="flex items-center justify-center gap-2 text-white/90">
-              <Phone className="w-5 h-5" />
-              <span>Call: </span>
-              <a href="tel:+918826444334" className="font-bold hover:text-[#4ade80]">
-                +91-88264-44334
-              </a>
-            </div>
-          </motion.div>
-        </div>
-      </section>
-    </div>
+      <PageContent />
+    </>
   )
 }


### PR DESCRIPTION
## Phase 3: National Premium Locality SEO Expansion

### 41 new locality pages across 9 major cities:

**Mumbai (8):** Juhu, Hiranandani, Lodha, Versova, Colaba, Goregaon, Thane, Navi Mumbai
**Pune (4):** Kalyani Nagar, Hinjewadi, Viman Nagar, Baner
**Bangalore (6):** Sarjapur Road, Electronic City, Bellandur, HSR Layout, Jayanagar, Indiranagar
**Hyderabad (5):** Banjara Hills, Kondapur, Madhapur, Gachibowli, Secunderabad
**Chennai (4):** Mylapore, Velachery, T Nagar, Nungambakkam
**Kolkata (4):** Salt Lake, Ballygunge, Park Street, New Town
**Ahmedabad (4):** SG Highway, Bodakdev, Prahlad Nagar, Satellite
**Jaipur (3):** C-Scheme, Malviya Nagar, Vaishali Nagar
**Lucknow (3):** Gomti Nagar, Hazratganj, Aliganj

Each page includes LocalitySchema, full metadata, PageContent with hero, stats, areas served, FAQs, and WhatsApp CTA.