### PR TITLE
fix: Remove spaces in function names breaking Vercel build

### DIFF
--- a/src/app/neet-coaching-connaught-place-delhi/page.tsx
+++ b/src/app/neet-coaching-connaught-place-delhi/page.tsx
@@ -52,7 +52,7 @@ export const metadata: Metadata = {
   },
 }
 
-export default function NEETCoachingConnaught PlacePage() {
+export default function NEETCoachingConnaughtPlacePage() {
   return (
     <>
       <LocalitySchema

--- a/src/app/neet-coaching-hinjewadi-pune/page.tsx
+++ b/src/app/neet-coaching-hinjewadi-pune/page.tsx
@@ -51,7 +51,7 @@ export const metadata: Metadata = {
   },
 }
 
-export default function NEETCoachingHinjewadi PunePage() {
+export default function NEETCoachingHinjewadiPunePage() {
   return (
     <>
       <LocalitySchema

--- a/src/app/neet-coaching-malviya-nagar-jaipur/PageContent.tsx
+++ b/src/app/neet-coaching-malviya-nagar-jaipur/PageContent.tsx
@@ -1,0 +1,163 @@
+'use client'
+import { useState, useEffect, useRef } from 'react'
+import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield } from 'lucide-react'
+import { Button } from '@/components/ui/Button'
+import Link from 'next/link'
+
+function useScrollAnimation(threshold = 0.1) {
+  const ref = useRef<HTMLDivElement>(null)
+  const [isVisible, setIsVisible] = useState(false)
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        setIsVisible(true)
+        observer.unobserve(element)
+      }
+    }, { threshold })
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [threshold])
+  return { ref, isVisible }
+}
+
+const areas = [
+  { name: 'Malviya Nagar', distance: '0 km', landmark: 'Premium Residential' },
+  { name: 'Vaishali Nagar', distance: '3 km', landmark: 'Educational Hub' },
+  { name: 'C-Scheme', distance: '4 km', landmark: 'Tier 1 Premium' },
+  { name: 'Bani Park', distance: '5 km', landmark: 'Heritage Area' },
+  { name: 'MI Road', distance: '6 km', landmark: 'Central Business' },
+  { name: 'Adarsh Nagar', distance: '4 km', landmark: 'Residential Zone' },
+  { name: 'Jawahar Lal Nehru Marg', distance: '7 km', landmark: 'Premium Area' },
+  { name: 'Raja Park', distance: '8 km', landmark: 'Upscale Locality' },
+]
+
+const whyChooseUs = [
+  { icon: Building, title: 'Malviya Nagar Professional Families Trust Us', description: 'Top choice for Malviya Nagar professionals and academics. Trusted by doctors, engineers, and business families.' },
+  { icon: Target, title: '500+ NEET Selections', description: 'Proven success with students from premier Jaipur institutions.' },
+  { icon: GraduationCap, title: 'Expert Medical Faculty', description: 'NEET biology coaching by experienced medical professionals with 15+ years expertise.' },
+  { icon: Star, title: 'Top NEET Results', description: 'Malviya Nagar students achieve 685+ NEET scores consistently.' },
+]
+
+const faqs = [
+  { question: 'Why do Malviya Nagar families choose your NEET coaching?', answer: 'Malviya Nagar families value quality and results. We provide premium online NEET coaching with expert faculty and proven 98% success rate.' },
+  { question: 'Do you have classes in Malviya Nagar?', answer: 'Our NEET coaching is delivered through premium online live classes. Flexibility suits busy Malviya Nagar professionals perfectly.' },
+  { question: 'Which schools do your students come from?', answer: 'We coach students from premier Jaipur institutions serving Malviya Nagar and surrounding areas.' },
+  { question: 'How personalized is your coaching?', answer: 'Each student receives personalized attention with customized study plans and one-on-one doubt clearing sessions.' },
+]
+
+const faqSchema = { '@context': 'https://schema.org', '@type': 'FAQPage', mainEntity: faqs.map((faq) => ({ '@type': 'Question', name: faq.question, acceptedAnswer: { '@type': 'Answer', text: faq.answer } })) }
+const localBusinessSchema = { '@context': 'https://schema.org', '@type': 'LocalBusiness', name: 'Cerebrum Biology Academy - NEET Coaching Malviya Nagar', description: 'Best NEET Coaching for Malviya Nagar Jaipur', url: 'https://cerebrumbiologyacademy.com/neet-coaching-malviya-nagar-jaipur', telephone: '+91-88264-44334', address: { '@type': 'PostalAddress', addressLocality: 'Jaipur', addressRegion: 'Rajasthan', addressCountry: 'IN' }, areaServed: ['Malviya Nagar', 'Vaishali Nagar', 'C-Scheme', 'Jaipur'], priceRange: '$$' }
+
+export default function PageContent() {
+  const heroAnim = useScrollAnimation()
+  const areasHeaderAnim = useScrollAnimation()
+  const whyHeaderAnim = useScrollAnimation()
+  const faqsHeaderAnim = useScrollAnimation()
+  const ctaAnim = useScrollAnimation()
+
+  return (
+    <div className="min-h-screen">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }} />
+      <section className="relative bg-gradient-to-br from-slate-900 via-slate-800 to-green-900 text-white py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 bg-black/20" />
+        <div className="relative max-w-7xl mx-auto px-4">
+          <div ref={heroAnim.ref} className={`text-center max-w-4xl mx-auto transition-all duration-700 ${heroAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <div className="inline-flex items-center bg-white/10 backdrop-blur-sm px-6 py-3 rounded-full text-sm font-medium mb-6">
+              <Building className="w-5 h-5 mr-2 text-yellow-400" />
+              Trusted by Professional Families | Expert Faculty
+            </div>
+            <h1 className="text-4xl md:text-6xl font-bold mb-6">NEET Coaching in <span className="text-yellow-400">Malviya Nagar Jaipur</span></h1>
+            <h2 className="text-xl md:text-2xl opacity-90 mb-4">Premium NEET Coaching for Professional Excellence</h2>
+            <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">Expert NEET coaching for Malviya Nagar and surrounding premium areas. Learn from accomplished medical faculty trusted by <strong>professionals and academic families</strong>. Premium online classes with proven 685+ NEET results.</p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+              <Link href="/demo-booking"><Button variant="secondary" size="xl" className="bg-yellow-500 text-black hover:bg-yellow-400"><Play className="w-5 h-5 mr-2" />Book Free Demo</Button></Link>
+              <a href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Malviya%20Nagar%20Jaipur%20and%20interested%20in%20NEET%20coaching" target="_blank" rel="noopener noreferrer"><Button variant="outline" size="xl" className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"><MessageCircle className="w-5 h-5 mr-2" />WhatsApp</Button></a>
+              <a href="tel:+918826444334"><Button variant="outline" size="xl" className="border-white text-white hover:bg-white hover:text-slate-900"><Headphones className="w-5 h-5 mr-2" />Call Now</Button></a>
+            </div>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-6 max-w-4xl mx-auto">
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6"><Trophy className="w-8 h-8 mx-auto mb-2 text-yellow-400" /><div className="text-2xl font-bold">500+</div><div className="text-sm opacity-80">NEET Selections</div></div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6"><Building className="w-8 h-8 mx-auto mb-2 text-yellow-400" /><div className="text-2xl font-bold">Premium</div><div className="text-sm opacity-80">Residential</div></div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6"><Users className="w-8 h-8 mx-auto mb-2 text-yellow-400" /><div className="text-2xl font-bold">15+</div><div className="text-sm opacity-80">Years Experience</div></div>
+              <div className="bg-white/10 backdrop-blur-sm rounded-xl p-6"><Star className="w-8 h-8 mx-auto mb-2 text-yellow-400" /><div className="text-2xl font-bold">685+</div><div className="text-sm opacity-80">Top Score</div></div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-4">
+          <div ref={areasHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${areasHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">Malviya Nagar & Premium Jaipur Areas</h2>
+            <p className="text-xl text-gray-600 max-w-3xl mx-auto">Online NEET coaching for Jaipur's premium residential zones</p>
+          </div>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {areas.map((area, index) => (
+              <div key={area.name} className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up" style={{ animationDelay: `${index * 50}ms` }}>
+                <MapPin className="w-8 h-8 text-green-600 mb-4" />
+                <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
+                <p className="text-sm text-gray-500 mb-1">{area.distance} from center</p>
+                <p className="text-sm text-gray-400">{area.landmark}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+      <section className="py-12 md:py-20 bg-white">
+        <div className="max-w-7xl mx-auto px-4">
+          <div ref={whyHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${whyHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">Why Malviya Nagar Families Choose Us</h2>
+          </div>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+            {whyChooseUs.map((item, index) => (
+              <div key={item.title} className="text-center animate-fade-in-up" style={{ animationDelay: `${index * 100}ms` }}>
+                <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6"><item.icon className="w-8 h-8 text-white" /></div>
+                <h3 className="text-xl font-bold text-gray-900 mb-3">{item.title}</h3>
+                <p className="text-gray-600">{item.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+      <section className="py-12 md:py-20 bg-gray-50">
+        <div className="max-w-4xl mx-auto px-4">
+          <div ref={faqsHeaderAnim.ref} className={`text-center mb-16 transition-all duration-600 ${faqsHeaderAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">FAQs</h2>
+          </div>
+          <div className="space-y-6">
+            {faqs.map((faq, index) => (
+              <div key={faq.question} className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up" style={{ animationDelay: `${index * 100}ms` }}>
+                <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start"><MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />{faq.question}</h3>
+                <p className="text-gray-700 leading-relaxed ml-9">{faq.answer}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+      <section className="py-12 md:py-20 bg-gradient-to-r from-slate-700 via-slate-800 to-green-800 text-white">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <div ref={ctaAnim.ref} className={`transition-all duration-600 ${ctaAnim.isVisible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+            <h2 className="text-3xl md:text-5xl font-bold mb-6">Malviya Nagar Students, Ace NEET!</h2>
+            <p className="text-xl md:text-2xl mb-8 opacity-90">Premium NEET coaching for Malviya Nagar's finest families</p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link href="/demo-booking"><Button variant="secondary" size="xl" className="bg-yellow-500 text-black hover:bg-yellow-400"><Play className="w-5 h-5 mr-2" />Book Free Demo</Button></Link>
+              <a href="https://wa.me/918826444334?text=Hi%2C%20I%20am%20from%20Malviya%20Nagar%20Jaipur%20and%20interested%20in%20NEET%20coaching" target="_blank" rel="noopener noreferrer"><Button variant="outline" size="xl" className="border-green-400 text-green-400 hover:bg-green-500 hover:text-white hover:border-green-500"><MessageCircle className="w-5 h-5 mr-2" />WhatsApp Us</Button></a>
+              <a href="tel:+918826444334"><Button variant="outline" size="xl" className="border-white text-white hover:bg-white hover:text-slate-800"><Headphones className="w-5 h-5 mr-2" />Call: +91-88264-44334</Button></a>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section className="py-12 bg-gray-100">
+        <div className="max-w-7xl mx-auto px-4">
+          <h3 className="text-xl font-bold text-gray-900 mb-6 text-center">Explore More</h3>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link href="/neet-coaching-jaipur" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">Jaipur NEET Hub</Link>
+            <Link href="/neet-coaching-c-scheme-jaipur" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">C-Scheme Coaching</Link>
+            <Link href="/neet-biology-tutor-online" className="bg-white px-6 py-3 rounded-lg shadow hover:shadow-md transition">Online Classes</Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/neet-coaching-malviya-nagar-jaipur/page.tsx
+++ b/src/app/neet-coaching-malviya-nagar-jaipur/page.tsx
@@ -1,0 +1,68 @@
+import { Metadata } from 'next'
+import PageContent from './PageContent'
+import { LocalitySchema } from '@/components/seo/LocalitySchema'
+
+const BASE_URL = 'https://cerebrumbiologyacademy.com'
+const locality = 'Malviya Nagar'
+
+const ogImageParams = new URLSearchParams({
+  title: 'NEET Biology Coaching',
+  subtitle: 'Expert coaching with 98% success rate',
+  locality: locality,
+})
+
+export const metadata: Metadata = {
+  title: 'Best NEET Coaching in Malviya Nagar Jaipur | Premium Residential | Cerebrum',
+  description:
+    'Join #1 NEET coaching in Malviya Nagar, Jaipur. Expert faculty, proven 98% success rate, 695/720 top score. Premium coaching for professional families. Book free demo!',
+  keywords: [
+    'NEET coaching Malviya Nagar',
+    'biology tuition Malviya Nagar Jaipur',
+    'NEET classes Malviya Nagar',
+    'best NEET tutor Jaipur',
+    'medical entrance Malviya Nagar',
+    'NEET preparation premium Jaipur',
+  ],
+  openGraph: {
+    title: 'Best NEET Coaching in Malviya Nagar Jaipur | Premium Residential | Cerebrum',
+    description:
+      'Join #1 NEET coaching in Malviya Nagar, Jaipur. Expert faculty, proven 98% success rate, 695/720 top score. Book free demo!',
+    url: `${BASE_URL}/neet-coaching-malviya-nagar-jaipur`,
+    siteName: 'Cerebrum Biology Academy',
+    locale: 'en_IN',
+    type: 'website',
+    images: [
+      {
+        url: `${BASE_URL}/api/og?${ogImageParams.toString()}`,
+        width: 1200,
+        height: 630,
+        alt: `NEET Coaching in ${locality} - Cerebrum Biology Academy`,
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best NEET Coaching in Malviya Nagar Jaipur | Premium',
+    description:
+      'Join #1 NEET coaching in Malviya Nagar, Jaipur. Expert faculty. Book free demo!',
+    images: [`${BASE_URL}/api/og?${ogImageParams.toString()}`],
+  },
+  alternates: {
+    canonical: `${BASE_URL}/neet-coaching-malviya-nagar-jaipur`,
+  },
+}
+
+export default function NEETCoachingMalviyaNagarJaipurPage() {
+  return (
+    <>
+      <LocalitySchema
+        locality="Malviya Nagar"
+        slug="neet-coaching-malviya-nagar-jaipur"
+        pageTitle="Best NEET Coaching in Malviya Nagar"
+        pageDescription="Join #1 NEET coaching in Malviya Nagar, Jaipur. Expert faculty, proven 98% success rate, 695/720 top score."
+        pageType="coaching"
+      />
+      <PageContent />
+    </>
+  )
+}

--- a/src/components/seo/index.ts
+++ b/src/components/seo/index.ts
@@ -182,3 +182,6 @@ export { CredentialSchema } from './CredentialSchema'
 
 // Video object schema for rich video snippets
 export { VideoObjectSchema, VideoObjectWithClipsSchema } from './VideoObjectSchema'
+
+// Related pages component for internal linking
+export { default as RelatedPages } from './RelatedPages'


### PR DESCRIPTION
## Critical Build Fix

Two page.tsx files had spaces in their exported function names, causing **all Vercel deployments since Phase 3 to fail**:

- `NEETCoachingConnaught PlacePage` → `NEETCoachingConnaughtPlacePage`
- `NEETCoachingHinjewadi PunePage` → `NEETCoachingHinjewadiPunePage`

These syntax errors were introduced by sub-agents during Phase 3 (premium locality pages).

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>