### PR TITLE
Fix build errors: string literals + missing LandingPageTemplate

### DIFF
--- a/src/app/neet-coaching-amity-international/PageContent.tsx
+++ b/src/app/neet-coaching-amity-international/PageContent.tsx
@@ -78,11 +78,11 @@ export default function PageContent() {
   const faqs = [
     {
       question: 'How does Amity CBSE compare to other board students for NEET?',
-      answer: 'Amity CBSE students have strong advantage - CBSE is perfectly aligned with NEET. Combined with Amity\'s competitive environment, students are well-positioned for 650+ NEET scores with proper coaching.',
+      answer: "Amity CBSE students have strong advantage - CBSE is perfectly aligned with NEET. Combined with Amity\'s competitive environment, students are well-positioned for 650+ NEET scores with proper coaching.",
     },
     {
       question: 'Can I manage both Amity studies and NEET preparation?',
-      answer: 'Yes! Amity\'s CBSE curriculum and NEET have significant overlap. Our program coordinates with your Amity schedule, ensuring both board excellence and NEET success without over-stress.',
+      answer: "Yes! Amity\'s CBSE curriculum and NEET have significant overlap. Our program coordinates with your Amity schedule, ensuring both board excellence and NEET success without over-stress.",
     },
     {
       question: 'What is the NEET success rate for Amity students?',
@@ -93,7 +93,7 @@ export default function PageContent() {
       answer: 'Yes! We serve Amity students across all campuses - Delhi, Noida, Gurgaon, Bangalore, Mumbai and others. Localized support adapted to your campus while maintaining consistent excellence standards.',
     },
     {
-      question: 'How does Amity\'s competitive environment help NEET?',
+      question: "How does Amity\'s competitive environment help NEET?",
       answer: 'Amity students are inherently competitive and achievement-focused. This culture accelerates NEET preparation. Our coaching channels this competitive spirit into focused NEET excellence.',
     },
     {

--- a/src/app/neet-coaching-baner-pune/PageContent.tsx
+++ b/src/app/neet-coaching-baner-pune/PageContent.tsx
@@ -58,7 +58,7 @@ const whyChooseUs = [
     icon: Gem,
     title: 'Premium Residential Specialist',
     description:
-      'Baner is Pune\'s premium residential area home to IT professionals and affluent families. We specialize in coaching for ambitious students from high-income households.',
+      "Baner is Pune's premium residential area home to IT professionals and affluent families. We specialize in coaching for ambitious students from high-income households.",
   },
   {
     icon: Target,
@@ -89,7 +89,7 @@ const faqs = [
   {
     question: 'How do you cater to premium Baner families?',
     answer:
-      'Baner represents Pune\'s premium lifestyle. We offer personalized attention, flexible schedules, detailed progress reports, and result-oriented teaching tailored for high-achieving families with busy schedules.',
+      "Baner represents Pune's premium lifestyle. We offer personalized attention, flexible schedules, detailed progress reports, and result-oriented teaching tailored for high-achieving families with busy schedules.",
   },
   {
     question: 'Which schools do your Baner students attend?',
@@ -154,10 +154,10 @@ export default function PageContent() {
               NEET Coaching in <span className="text-yellow-400">Baner</span>
             </h1>
             <h2 className="text-xl md:text-2xl opacity-90 mb-4">
-              Premium Biology Coaching for Pune&apos;s Most Sought-After Locality
+              Premium Biology Coaching for Pune's Most Sought-After Locality
             </h2>
             <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
-              Exclusive NEET coaching for Baner, Balewadi, and premium Pune families. Learn from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by Baner&apos;s elite families.
+              Exclusive NEET coaching for Baner, Balewadi, and premium Pune families. Learn from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by Baner's elite families.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
               <Link href="/demo-booking">
@@ -275,7 +275,7 @@ export default function PageContent() {
               Baner Students, Excel in NEET!
             </h2>
             <p className="text-xl md:text-2xl mb-8 opacity-90">
-              Premium NEET coaching for Pune&apos;s most premium families
+              Premium NEET coaching for Pune's most premium families
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Link href="/demo-booking">

--- a/src/app/neet-coaching-banjara-hills-hyderabad/PageContent.tsx
+++ b/src/app/neet-coaching-banjara-hills-hyderabad/PageContent.tsx
@@ -61,7 +61,7 @@ const faqs = [
 {
     question: 'Why do Banjara Hills families prefer online NEET coaching?',
     answer:
-      'Banjara Hills families value premium quality and privacy. Online NEET coaching offers world-class AIIMS faculty without commute, perfect for government officials' busy schedules. High-speed connectivity and gated community infrastructure support seamless learning.',
+      "Banjara Hills families value premium quality and privacy. Online NEET coaching offers world-class AIIMS faculty without commute, perfect for government officials' busy schedules. High-speed connectivity and gated community infrastructure support seamless learning.",
   },
   {
     question: 'How do you support government official families?',

--- a/src/app/neet-coaching-bhubaneswar/PageContent.tsx
+++ b/src/app/neet-coaching-bhubaneswar/PageContent.tsx
@@ -56,9 +56,9 @@ const bhubaneswarAreas = [
 const whyChooseUs = [
   {
     icon: BookOpen,
-    title: 'Odisha Education Hub',
+    title: "Odisha Education Hub",
     description:
-      'Bhubaneswar is Odisha\'s premier education hub. Our NEET coaching serves students from top schools like DAV Public, SAI International, and KIIT International.',
+      "Bhubaneswar is Odisha's premier education hub. Our NEET coaching serves students from top schools like DAV Public, SAI International, and KIIT International.",
   },
   {
     icon: Target,
@@ -89,7 +89,7 @@ const faqs = [
   {
     question: 'Is NEET coaching important for Bhubaneswar students?',
     answer:
-      'Yes! With 13000+ aspirants in Odisha and moderate competitive intensity, structured NEET coaching gives you a significant advantage. Bhubaneswar\'s position as an education hub makes it ideal for quality online coaching.',
+      "Yes! With 13000+ aspirants in Odisha and moderate competitive intensity, structured NEET coaching gives you a significant advantage. Bhubaneswar's position as an education hub makes it ideal for quality online coaching.",
   },
   {
     question: 'What schools do your Bhubaneswar students come from?',

--- a/src/app/neet-coaching-bishops-school-pune/PageContent.tsx
+++ b/src/app/neet-coaching-bishops-school-pune/PageContent.tsx
@@ -72,16 +72,16 @@ export default function PageContent() {
       answer: 'ICSE/ISC students show strong NEET performance with 85%+ qualification and 630+ average scores. The rigorous curriculum provides excellent foundation. We bridge any content gaps while leveraging the strong conceptual understanding developed by ICSE/ISC.',
     },
     {
-      question: 'What advantage does Bishop\'s School Camp location provide?',
-      answer: 'Pune is a major medical education hub with strong coaching infrastructure. Camp area is Pune\'s premium educational district. This environment, combined with Bishop\'s academic excellence, creates ideal NEET preparation setting.',
+      question: "What advantage does Bishop\'s School Camp location provide?",
+      answer: "Pune is a major medical education hub with strong coaching infrastructure. Camp area is Pune\'s premium educational district. This environment, combined with Bishop\'s academic excellence, creates ideal NEET preparation setting.",
     },
     {
       question: 'Can I prepare for ICSE/ISC boards and NEET together?',
       answer: 'Yes! ICSE/ISC and NEET have significant science overlap. Our program ensures both board excellence (90+) and NEET strength (630+) through synchronized preparation that prevents redundant studying.',
     },
     {
-      question: 'What is the NEET success rate for Bishop\'s School students?',
-      answer: 'Bishop\'s School students show 85%+ NEET qualification with 630+ average scores. The school\'s academic culture and ICSE/ISC rigor provide strong platform for medical entrance success.',
+      question: "What is the NEET success rate for Bishop\'s School students?",
+      answer: "Bishop\'s School students show 85%+ NEET qualification with 630+ average scores. The school\'s academic culture and ICSE/ISC rigor provide strong platform for medical entrance success.",
     },
     {
       question: 'How do you handle ICSE vs ISC differences for NEET?',
@@ -89,7 +89,7 @@ export default function PageContent() {
     },
     {
       question: 'Is Pune location good for NEET preparation?',
-      answer: 'Pune is excellent for NEET preparation with strong coaching centers, medical colleges, and educational infrastructure. Bishop\'s School location in premium Camp area provides access to best resources while maintaining school focus.',
+      answer: "Pune is excellent for NEET preparation with strong coaching centers, medical colleges, and educational infrastructure. Bishop\'s School location in premium Camp area provides access to best resources while maintaining school focus.",
     },
   ]
 

--- a/src/app/neet-coaching-bodakdev-ahmedabad/PageContent.tsx
+++ b/src/app/neet-coaching-bodakdev-ahmedabad/PageContent.tsx
@@ -89,7 +89,7 @@ const faqs = [
   {
     question: 'Do you have classes in Bodakdev?',
     answer:
-      'Our NEET coaching is delivered through premium online live classes. This flexibility is ideal for Bodakdev\'s busy professional families. We offer recorded lectures, comprehensive study material, and regular assessments.',
+      "Our NEET coaching is delivered through premium online live classes. This flexibility is ideal for Bodakdev's busy professional families. We offer recorded lectures, comprehensive study material, and regular assessments.",
   },
   {
     question: 'Which schools do your Bodakdev students come from?',

--- a/src/app/neet-coaching-c-scheme-jaipur/PageContent.tsx
+++ b/src/app/neet-coaching-c-scheme-jaipur/PageContent.tsx
@@ -94,7 +94,7 @@ const faqs = [
   {
     question: 'Which schools do your C-Scheme students attend?',
     answer:
-      'We coach students from Rajkiya Vidyapith, Maharaja College, D.A.V. Public School, St. Xavier\'s, and other premier Jaipur institutions.',
+      "We coach students from Rajkiya Vidyapith, Maharaja College, D.A.V. Public School, St. Xavier's, and other premier Jaipur institutions.",
   },
   {
     question: 'How is your coaching customized for C-Scheme students?',

--- a/src/app/neet-coaching-chandni-chowk-delhi/PageContent.tsx
+++ b/src/app/neet-coaching-chandni-chowk-delhi/PageContent.tsx
@@ -94,7 +94,7 @@ const faqs = [
   {
     question: 'How do business families benefit from your NEET coaching?',
     answer:
-      'Many Chandni Chowk families have business backgrounds and value education highly. Our structured approach, result-oriented teaching, and proven 98% success rate align perfectly with business families\' expectations.',
+      "Many Chandni Chowk families have business backgrounds and value education highly. Our structured approach, result-oriented teaching, and proven 98% success rate align perfectly with business families' expectations.",
   },
   {
     question: 'Can I study NEET from Old Delhi?',

--- a/src/app/neet-coaching-colaba-mumbai/PageContent.tsx
+++ b/src/app/neet-coaching-colaba-mumbai/PageContent.tsx
@@ -87,7 +87,7 @@ const faqs = [
       'Our main center is in Greater Noida. For Colaba and South Mumbai residents, we offer exclusive live online NEET classes with personalized attention. Many affluent South Mumbai families prefer online coaching for convenience and security. Our comprehensive material and recorded lectures ensure uninterrupted preparation.',
   },
   {
-    question: 'How do you understand Navy families\' needs?',
+    question: "How do you understand Navy families\' needs?",
     answer:
       'Navy families in Colaba and Navy Nagar value discipline, structure, and excellence. We mirror these values through fixed schedules, rigorous testing, detailed progress reports, and result-oriented teaching. Our approach is tailored for military and naval families.',
   },

--- a/src/app/neet-coaching-connaught-place-delhi/PageContent.tsx
+++ b/src/app/neet-coaching-connaught-place-delhi/PageContent.tsx
@@ -92,7 +92,7 @@ const faqs = [
       'St. Columba\'s School, Modern School Barakhamba, Convent of Jesus & Mary, and several premium institutions serve the Connaught Place area. We have successfully coached students from all these schools.',
   },
   {
-    question: 'How do your classes cater to Central Delhi\'s premium students?',
+    question: "How do your classes cater to Central Delhi\'s premium students?",
     answer:
       'Students from premium schools already have strong fundamentals. Our coaching focuses on competitive advantage, advanced problem-solving, and achieving 680+ NEET scores for top college admission.',
   },

--- a/src/app/neet-coaching-cuttack/PageContent.tsx
+++ b/src/app/neet-coaching-cuttack/PageContent.tsx
@@ -89,7 +89,7 @@ const faqs = [
   {
     question: 'What is the advantage of SCB Medical College proximity?',
     answer:
-      'Cuttack\'s location near SCB Medical College creates inspiration for NEET aspirants. Many of our students aspire to join this prestigious college. Our coaching helps Cuttack students prepare to secure SCB Medical and other top AIIMS/NLM colleges.',
+      "Cuttack's location near SCB Medical College creates inspiration for NEET aspirants. Many of our students aspire to join this prestigious college. Our coaching helps Cuttack students prepare to secure SCB Medical and other top AIIMS/NLM colleges.",
   },
   {
     question: 'What schools do your Cuttack students come from?',
@@ -99,7 +99,7 @@ const faqs = [
   {
     question: 'How does twin city with Bhubaneswar help?',
     answer:
-      'Cuttack and Bhubaneswar form Odisha\'s twin city - a combined education and cultural hub. Our online coaching serves both cities with unified curriculum and expertise, helping students from both areas compete nationally.',
+      "Cuttack and Bhubaneswar form Odisha's twin city - a combined education and cultural hub. Our online coaching serves both cities with unified curriculum and expertise, helping students from both areas compete nationally.",
   },
 ]
 

--- a/src/app/neet-coaching-gandhinagar/PageContent.tsx
+++ b/src/app/neet-coaching-gandhinagar/PageContent.tsx
@@ -168,7 +168,7 @@ export default function PageContent() {
             </h1>
 
             <h2 className="text-xl md:text-2xl opacity-90 mb-4">
-              Premium Biology Coaching for Gujarat&apos;s State Capital Families
+              Premium Biology Coaching for Gujarat's State Capital Families
             </h2>
 
             <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">

--- a/src/app/neet-coaching-goa/PageContent.tsx
+++ b/src/app/neet-coaching-goa/PageContent.tsx
@@ -58,7 +58,7 @@ const whyChooseUs = [
     icon: Globe,
     title: 'NRI & Expat Friendly',
     description:
-      'Perfect for Goa\'s high NRI and expat population. Flexible timings, international payment options, and timezone-friendly live classes for families abroad.',
+      "Perfect for Goa's high NRI and expat population. Flexible timings, international payment options, and timezone-friendly live classes for families abroad.",
   },
   {
     icon: Target,
@@ -76,7 +76,7 @@ const whyChooseUs = [
     icon: Star,
     title: 'High Per-Capita Income Region',
     description:
-      'Goa\'s high per-capita income families value quality education. Our premium coaching matches the expectations of affluent Goa households.',
+      "Goa's high per-capita income families value quality education. Our premium coaching matches the expectations of affluent Goa households.",
   },
 ]
 
@@ -84,7 +84,7 @@ const faqs = [
   {
     question: 'Do you have a physical coaching center in Goa?',
     answer:
-      'We offer premium live online NEET classes accessible across all of Goa - Panaji, Margao, Vasco, Mapusa, and beyond. Our online model suits Goa\'s unique demographic of NRI families and expats who value flexibility. Many students prefer online classes as they can continue learning even if they relocate.',
+      "We offer premium live online NEET classes accessible across all of Goa - Panaji, Margao, Vasco, Mapusa, and beyond. Our online model suits Goa's unique demographic of NRI families and expats who value flexibility. Many students prefer online classes as they can continue learning even if they relocate.",
   },
   {
     question: 'Is NEET coaching suitable for Goa students?',
@@ -94,12 +94,12 @@ const faqs = [
   {
     question: 'What schools do your Goa students come from?',
     answer:
-      'We have students from Sharada Mandir, People\'s High School, Mushtifund School, Sesa Goa School, and other premier Goan schools. Our coaching is suitable for students from both English and vernacular medium backgrounds.',
+      "We have students from Sharada Mandir, People's High School, Mushtifund School, Sesa Goa School, and other premier Goan schools. Our coaching is suitable for students from both English and vernacular medium backgrounds.",
   },
   {
     question: 'How does online coaching work for NRI families in Goa?',
     answer:
-      'Many NRI families in Goa choose our online NEET coaching for flexibility and global-standard teaching. Flexible batch timings accommodate different timezones, recorded sessions allow flexible learning, and you can continue your preparation even if you relocate. Perfect for Goa\'s expat-heavy population.',
+      "Many NRI families in Goa choose our online NEET coaching for flexibility and global-standard teaching. Flexible batch timings accommodate different timezones, recorded sessions allow flexible learning, and you can continue your preparation even if you relocate. Perfect for Goa's expat-heavy population.",
   },
 ]
 
@@ -168,7 +168,7 @@ export default function PageContent() {
             </h1>
 
             <h2 className="text-xl md:text-2xl opacity-90 mb-4">
-              Premium Biology Coaching for Goa&apos;s High Per-Capita Income Families
+              Premium Biology Coaching for Goa's High Per-Capita Income Families
             </h2>
 
             <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">

--- a/src/app/neet-coaching-green-park-delhi/PageContent.tsx
+++ b/src/app/neet-coaching-green-park-delhi/PageContent.tsx
@@ -167,7 +167,7 @@ export default function PageContent() {
             </h1>
 
             <h2 className="text-xl md:text-2xl opacity-90 mb-4">
-              Premium Biology Coaching Near Delhi&apos;s Educational Hub
+              Premium Biology Coaching Near Delhi's Educational Hub
             </h2>
 
             <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">

--- a/src/app/neet-coaching-hinjewadi-pune/PageContent.tsx
+++ b/src/app/neet-coaching-hinjewadi-pune/PageContent.tsx
@@ -69,7 +69,7 @@ const whyChooseUs = [
     icon: GraduationCap,
     title: 'AIIMS Faculty',
     description:
-      'Dr. Shekhar C Singh, AIIMS Alumnus with 15+ years experience coaching motivated IT professionals\' children.',
+      "Dr. Shekhar C Singh, AIIMS Alumnus with 15+ years experience coaching motivated IT professionals' children.",
   },
   {
     icon: Star,
@@ -152,7 +152,7 @@ export default function PageContent() {
               NEET Coaching in <span className="text-yellow-400">Hinjewadi</span>
             </h1>
             <h2 className="text-xl md:text-2xl opacity-90 mb-4">
-              Premium Biology Coaching for Pune&apos;s IT Corridor
+              Premium Biology Coaching for Pune's IT Corridor
             </h2>
             <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
               Exclusive NEET coaching for Hinjewadi and Rajiv Gandhi IT Park residents. Learn from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by IT families.

--- a/src/app/neet-coaching-hsr-layout-bangalore/PageContent.tsx
+++ b/src/app/neet-coaching-hsr-layout-bangalore/PageContent.tsx
@@ -168,7 +168,7 @@ export default function PageContent() {
             </h1>
 
             <h2 className="text-xl md:text-2xl opacity-90 mb-4">
-              Premium Biology Coaching for Bangalore&apos;s Startup Hub
+              Premium Biology Coaching for Bangalore's Startup Hub
             </h2>
 
             <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">

--- a/src/app/neet-coaching-kochi/PageContent.tsx
+++ b/src/app/neet-coaching-kochi/PageContent.tsx
@@ -94,7 +94,7 @@ const faqs = [
   {
     question: 'Which schools do Kochi students attend?',
     answer:
-      'Our Kochi students come from Choice School, Rajagiri, Toc-H, Bhavan\'s Vidya Mandir, and other premier institutions. Many follow Kerala curriculum; some attend CBSE schools. We cover both pathways with equal expertise and depth.',
+      "Our Kochi students come from Choice School, Rajagiri, Toc-H, Bhavan's Vidya Mandir, and other premier institutions. Many follow Kerala curriculum; some attend CBSE schools. We cover both pathways with equal expertise and depth.",
   },
   {
     question: 'How does Cerebrum help with Kerala + CBSE students?',

--- a/src/app/neet-coaching-la-martiniere/PageContent.tsx
+++ b/src/app/neet-coaching-la-martiniere/PageContent.tsx
@@ -52,7 +52,7 @@ export default function PageContent() {
   const faqAnim = useScrollAnimation()
 
   const laMartinieraAdvantages = [
-    { icon: Crown, title: 'Prestigious Colonial Heritage', description: 'La Martiniere\'s renowned excellence tradition creates strong academic foundation for NEET success' },
+    { icon: Crown, title: 'Prestigious Colonial Heritage', description: "La Martiniere's renowned excellence tradition creates strong academic foundation for NEET success" },
     { icon: BookOpen, title: 'ISC Curriculum Excellence', description: 'ISC provides rigorous science education with depth perfect for medical entrance preparation' },
     { icon: Users, title: 'Boys & Girls Excellence', description: 'La Martiniere Kolkata (boys/girls) and Lucknow campuses develop high-achieving NEET candidates' },
     { icon: Target, title: 'ISC-to-NEET Bridge', description: 'Custom mapping of ISC curriculum to NEET requirements filling any content gaps strategically' },
@@ -62,24 +62,24 @@ export default function PageContent() {
 
   const campuses = [
     { name: 'La Martiniere for Boys, Kolkata', heritage: '200+ years of excellence' },
-    { name: 'La Martiniere for Girls, Kolkata', heritage: 'Women\'s education pioneer' },
+    { name: 'La Martiniere for Girls, Kolkata', heritage: "Women's education pioneer" },
     { name: 'La Martiniere, Lucknow', heritage: 'Uttar Pradesh excellence hub' },
   ]
 
   const pricingPlans = [
     { name: 'Complete ISC-NEET Program', price: '₹37,999', description: '18-month comprehensive program bridging ISC to NEET with complete preparation' },
     { name: 'Intensive NEET Focus', price: '₹46,999', description: '12-month intensive program for La Martiniere students targeting medical entrance' },
-    { name: 'Premium 1:1 Coaching', price: '₹56,999', description: 'Personalized coaching for La Martiniere\'s high-achievers with ISC expertise' },
+    { name: 'Premium 1:1 Coaching', price: '₹56,999', description: "Personalized coaching for La Martiniere's high-achievers with ISC expertise" },
   ]
 
   const faqs = [
     {
       question: 'How does ISC prepare students for NEET differently than CBSE?',
-      answer: 'ISC offers excellent depth and rigor but has different chapter sequences and some content variations from NEET\'s NCERT basis. We provide comprehensive NCERT mapping for ISC students, leveraging your strong foundation while filling any gaps.',
+      answer: "ISC offers excellent depth and rigor but has different chapter sequences and some content variations from NEET's NCERT basis. We provide comprehensive NCERT mapping for ISC students, leveraging your strong foundation while filling any gaps.",
     },
     {
       question: 'What advantage does La Martiniere heritage give for NEET?',
-      answer: 'La Martiniere\'s 200+ year tradition of excellence develops disciplined, high-achieving students. This academic culture, combined with ISC rigor, creates excellent NEET foundation. We amplify this with specialized entrance exam preparation.',
+      answer: "La Martiniere's 200+ year tradition of excellence develops disciplined, high-achieving students. This academic culture, combined with ISC rigor, creates excellent NEET foundation. We amplify this with specialized entrance exam preparation.",
     },
     {
       question: 'Can La Martiniere students excel at both ISC and NEET?',
@@ -94,8 +94,8 @@ export default function PageContent() {
       answer: 'Yes! We serve La Martiniere students from all campuses - Kolkata boys, Kolkata girls, and Lucknow. Online platform ensures consistent excellence across locations.',
     },
     {
-      question: 'How do you address ISC\'s different curriculum for NEET?',
-      answer: 'We provide detailed ISC-to-NCERT mapping, ensuring you understand topics from both perspectives. This dual understanding deepens conceptual clarity crucial for NEET\'s application-based questions.',
+      question: "How do you address ISC's different curriculum for NEET?",
+      answer: "We provide detailed ISC-to-NCERT mapping, ensuring you understand topics from both perspectives. This dual understanding deepens conceptual clarity crucial for NEET's application-based questions.",
     },
   ]
 

--- a/src/app/neet-coaching-lodha-mumbai/PageContent.tsx
+++ b/src/app/neet-coaching-lodha-mumbai/PageContent.tsx
@@ -58,7 +58,7 @@ const whyChooseUs = [
     icon: Gem,
     title: 'Ultra-Premium Community',
     description:
-      'Lodha developments are India\'s most luxurious gated communities. We specialize in coaching for residents of premium properties with world-class amenities.',
+      "Lodha developments are India's most luxurious gated communities. We specialize in coaching for residents of premium properties with world-class amenities.",
   },
   {
     icon: Target,
@@ -168,12 +168,12 @@ export default function PageContent() {
             </h1>
 
             <h2 className="text-xl md:text-2xl opacity-90 mb-4">
-              Premium Biology Coaching for India&apos;s Most Luxurious Developments
+              Premium Biology Coaching for India's Most Luxurious Developments
             </h2>
 
             <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
               Exclusive NEET coaching for Lodha Park, Palava City, and premium gated communities.
-              Learn from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by India&apos;s
+              Learn from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by India's
               most affluent families.
             </p>
 
@@ -351,7 +351,7 @@ export default function PageContent() {
               Lodha Premium Residents, Excel in NEET!
             </h2>
             <p className="text-xl md:text-2xl mb-8 opacity-90">
-              Ultra-premium NEET coaching for India&apos;s most exclusive communities
+              Ultra-premium NEET coaching for India's most exclusive communities
             </p>
 
             <div className="flex flex-col sm:flex-row gap-4 justify-center">

--- a/src/app/neet-coaching-madurai/PageContent.tsx
+++ b/src/app/neet-coaching-madurai/PageContent.tsx
@@ -58,7 +58,7 @@ const whyChooseUs = [
     icon: Heart,
     title: 'Tamil Nadu Medical Heritage',
     description:
-      'Madurai has 10,000+ NEET aspirants from premier medical families. Cerebrum understands Tamil Nadu\'s medical education culture and delivers specialized NEET preparation.',
+      "Madurai has 10,000+ NEET aspirants from premier medical families. Cerebrum understands Tamil Nadu's medical education culture and delivers specialized NEET preparation.",
   },
   {
     icon: Building,

--- a/src/app/neet-coaching-malviya-nagar-jaipur/PageContent.tsx
+++ b/src/app/neet-coaching-malviya-nagar-jaipur/PageContent.tsx
@@ -34,7 +34,7 @@ const areas = [
 ]
 
 const whyChooseUs = [
-  { icon: Building, title: 'Malviya Nagar Professional Families Trust Us', description: 'Top choice for Malviya Nagar professionals and academics. Trusted by doctors, engineers, and business families.' },
+  { icon: Building, title: "Malviya Nagar Professional Families Trust Us", description: "Top choice for Malviya Nagar professionals and academics. Trusted by doctors, engineers, and business families." },
   { icon: Target, title: '500+ NEET Selections', description: 'Proven success with students from premier Jaipur institutions.' },
   { icon: GraduationCap, title: 'Expert Medical Faculty', description: 'NEET biology coaching by experienced medical professionals with 15+ years expertise.' },
   { icon: Star, title: 'Top NEET Results', description: 'Malviya Nagar students achieve 685+ NEET scores consistently.' },

--- a/src/app/neet-coaching-modern-school-delhi/PageContent.tsx
+++ b/src/app/neet-coaching-modern-school-delhi/PageContent.tsx
@@ -52,24 +52,24 @@ export default function PageContent() {
   const faqAnim = useScrollAnimation()
 
   const modernTradition = [
-    { icon: Award, title: 'Premium Excellence Heritage', description: 'Modern School\'s strong science tradition provides exceptional NEET foundation for medical aspirants' },
-    { icon: BookOpen, title: 'CBSE Science Mastery', description: 'Modern School emphasizes rigorous CBSE science education - perfect alignment with NEET requirements' },
-    { icon: Users, title: 'Peer Excellence Culture', description: 'High-achieving peer group at Modern School creates competitive excellence environment for NEET' },
-    { icon: Target, title: 'Proven Medical Success', description: 'Modern School has consistent history of students pursuing medical education and NEET success' },
-    { icon: Zap, title: 'Academic Rigor', description: 'Modern School\'s rigorous curriculum develops the conceptual depth required for NEET excellence' },
-    { icon: Building, title: 'Delhi\'s Prestigious Institution', description: 'Modern School\'s reputation and facilities support comprehensive NEET preparation alongside school' },
+    { icon: Award, title: "Premium Excellence Heritage", description: "Modern School's strong science tradition provides exceptional NEET foundation for medical aspirants" },
+    { icon: BookOpen, title: "CBSE Science Mastery", description: "Modern School emphasizes rigorous CBSE science education - perfect alignment with NEET requirements" },
+    { icon: Users, title: "Peer Excellence Culture", description: "High-achieving peer group at Modern School creates competitive excellence environment for NEET" },
+    { icon: Target, title: "Proven Medical Success", description: "Modern School has consistent history of students pursuing medical education and NEET success" },
+    { icon: Zap, title: "Academic Rigor", description: "Modern School's rigorous curriculum develops the conceptual depth required for NEET excellence" },
+    { icon: Building, title: "Delhi's Prestigious Institution", description: "Modern School's reputation and facilities support comprehensive NEET preparation alongside school" },
   ]
 
   const pricingPlans = [
-    { name: 'Complete NEET Mastery', price: '₹35,999', description: '18-month comprehensive program leveraging Modern School CBSE foundation for NEET' },
-    { name: 'Intensive NEET Focus', price: '₹45,999', description: '12-month intensive program for Modern School students targeting 650+ NEET scores' },
-    { name: 'Premium 1:1 Coaching', price: '₹55,999', description: 'Personalized one-on-one coaching designed for Modern School\'s high-achievers' },
+    { name: "Complete NEET Mastery", price: "₹35,999", description: "18-month comprehensive program leveraging Modern School CBSE foundation for NEET" },
+    { name: "Intensive NEET Focus", price: "₹45,999", description: "12-month intensive program for Modern School students targeting 650+ NEET scores" },
+    { name: "Premium 1:1 Coaching", price: "₹55,999", description: "Personalized one-on-one coaching designed for Modern School's high-achievers" },
   ]
 
   const faqs = [
     {
       question: 'How does Modern School CBSE prepare students for NEET?',
-      answer: 'Modern School\'s rigorous CBSE curriculum and emphasis on science excellence create a strong foundation for NEET. Combined with our specialized NEET coaching, students achieve 650+ scores while maintaining board excellence.',
+      answer: "Modern School's rigorous CBSE curriculum and emphasis on science excellence create a strong foundation for NEET. Combined with our specialized NEET coaching, students achieve 650+ scores while maintaining board excellence.",
     },
     {
       question: 'What makes Modern School students successful in NEET?',
@@ -81,7 +81,7 @@ export default function PageContent() {
     },
     {
       question: 'What is the NEET success rate for Modern School students?',
-      answer: 'Modern School students show 90%+ NEET qualification with 640+ average scores. The school\'s academic culture and CBSE alignment provide excellent foundation for medical entrance success.',
+      answer: "Modern School students show 90%+ NEET qualification with 640+ average scores. The school's academic culture and CBSE alignment provide excellent foundation for medical entrance success.",
     },
     {
       question: 'How do Modern School teachers and coaching work together?',
@@ -89,7 +89,7 @@ export default function PageContent() {
     },
     {
       question: 'Is NEET coaching necessary for Modern School students?',
-      answer: 'While Modern School provides excellent foundation, specialized NEET coaching bridges the gap between board exams and medical entrance. We help convert excellent CBSE understanding into 650+ NEET scores.',
+      answer: "While Modern School provides excellent foundation, specialized NEET coaching bridges the gap between board exams and medical entrance. We help convert excellent CBSE understanding into 650+ NEET scores.",
     },
   ]
 

--- a/src/app/neet-coaching-mohali/PageContent.tsx
+++ b/src/app/neet-coaching-mohali/PageContent.tsx
@@ -64,7 +64,7 @@ const whyChooseUs = [
     icon: Target,
     title: 'Punjab Education Hub',
     description:
-      'Mohali is Punjab\'s premier education hub with top schools. Our online NEET coaching serves ambitious families in this highly competitive educational landscape.',
+      "Mohali is Punjab's premier education hub with top schools. Our online NEET coaching serves ambitious families in this highly competitive educational landscape.",
   },
   {
     icon: GraduationCap,

--- a/src/app/neet-coaching-nashik/PageContent.tsx
+++ b/src/app/neet-coaching-nashik/PageContent.tsx
@@ -58,7 +58,7 @@ const whyChooseUs = [
     icon: Flame,
     title: 'Wine Country Excellence',
     description:
-      'Nashik\'s wine country families value premium education. Our NEET coaching matches the expectations of affluent, education-focused families in Maharashtra\'s premier wine region.',
+      "Nashik's wine country families value premium education. Our NEET coaching matches the expectations of affluent, education-focused families in Maharashtra's premier wine region.",
   },
   {
     icon: Target,
@@ -99,7 +99,7 @@ const faqs = [
   {
     question: 'How do wine country families benefit from your coaching?',
     answer:
-      'Nashik\'s wine country families appreciate our structured, result-oriented approach. Fixed schedules, regular progress reports, and focus on top results align with values of educated, successful families. Online format allows flexibility without compromising on quality coaching.',
+      "Nashik's wine country families appreciate our structured, result-oriented approach. Fixed schedules, regular progress reports, and focus on top results align with values of educated, successful families. Online format allows flexibility without compromising on quality coaching.",
   },
 ]
 
@@ -168,7 +168,7 @@ export default function PageContent() {
             </h1>
 
             <h2 className="text-xl md:text-2xl opacity-90 mb-4">
-              Premium Biology Coaching for Maharashtra&apos;s Wine Country Families
+              Premium Biology Coaching for Maharashtra's Wine Country Families
             </h2>
 
             <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">

--- a/src/app/neet-coaching-navi-mumbai/PageContent.tsx
+++ b/src/app/neet-coaching-navi-mumbai/PageContent.tsx
@@ -58,7 +58,7 @@ const whyChooseUs = [
     icon: Gem,
     title: 'Planned City Expert',
     description:
-      'Navi Mumbai is India\'s most planned city with premium gated communities. We specialize in coaching for residents of Kharghar, Palm Beach Road, and premium Belapur.',
+      "Navi Mumbai is India's most planned city with premium gated communities. We specialize in coaching for residents of Kharghar, Palm Beach Road, and premium Belapur.",
   },
   {
     icon: Target,
@@ -168,12 +168,12 @@ export default function PageContent() {
             </h1>
 
             <h2 className="text-xl md:text-2xl opacity-90 mb-4">
-              Premium Biology Coaching for India&apos;s Most Planned Metropolitan City
+              Premium Biology Coaching for India's Most Planned Metropolitan City
             </h2>
 
             <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
               Exclusive NEET coaching for Navi Mumbai, Kharghar, Vashi, and Belapur. Learn from{' '}
-              <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by Navi Mumbai&apos;s
+              <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by Navi Mumbai's
               premium families.
             </p>
 
@@ -351,7 +351,7 @@ export default function PageContent() {
               Navi Mumbai Students, Excel in NEET!
             </h2>
             <p className="text-xl md:text-2xl mb-8 opacity-90">
-              Premium NEET coaching for India&apos;s planned city residents
+              Premium NEET coaching for India's planned city residents
             </p>
 
             <div className="flex flex-col sm:flex-row gap-4 justify-center">

--- a/src/app/neet-coaching-new-town-kolkata/PageContent.tsx
+++ b/src/app/neet-coaching-new-town-kolkata/PageContent.tsx
@@ -70,7 +70,7 @@ const whyChooseUs = [
     icon: GraduationCap,
     title: 'Modern Medical Faculty',
     description:
-      'Expert NEET biology coaching by experienced medical professionals with 15+ years teaching background serving New Town\'s dynamic families.',
+      "Expert NEET biology coaching by experienced medical professionals with 15+ years teaching background serving New Town's dynamic families.",
   },
   {
     icon: Star,

--- a/src/app/neet-coaching-nungambakkam-chennai/PageContent.tsx
+++ b/src/app/neet-coaching-nungambakkam-chennai/PageContent.tsx
@@ -118,11 +118,11 @@ export default function PageContent() {
     <div className="min-h-screen">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={ { __html: JSON.stringify(faqSchema) } }
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
       />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={ { __html: JSON.stringify(localBusinessSchema) } }
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessSchema) }}
       />
 
       {/* Hero */}
@@ -239,7 +239,7 @@ export default function PageContent() {
               <div
                 key={area.name}
                 className="bg-white rounded-xl p-6 shadow-lg border border-gray-100 animate-fade-in-up"
-                style={ { animationDelay: `${index * 50}ms` } }
+                style={{ animationDelay: `${index * 50}ms` }}
               >
                 <MapPin className="w-8 h-8 text-green-600 mb-4" />
                 <h3 className="text-lg font-bold text-gray-900 mb-2">{area.name}</h3>
@@ -270,7 +270,7 @@ export default function PageContent() {
               <div
                 key={item.title}
                 className="text-center animate-fade-in-up"
-                style={ { animationDelay: `${index * 100}ms` } }
+                style={{ animationDelay: `${index * 100}ms` }}
               >
                 <div className="w-16 h-16 bg-gradient-to-br from-slate-700 to-green-700 rounded-2xl flex items-center justify-center mx-auto mb-6">
                   <item.icon className="w-8 h-8 text-white" />
@@ -300,7 +300,7 @@ export default function PageContent() {
               <div
                 key={faq.question}
                 className="bg-white rounded-xl p-8 shadow-lg animate-fade-in-up"
-                style={ { animationDelay: `${index * 100}ms` } }
+                style={{ animationDelay: `${index * 100}ms` }}
               >
                 <h3 className="text-xl font-bold text-gray-900 mb-4 flex items-start">
                   <MessageCircle className="w-6 h-6 mr-3 text-green-600 flex-shrink-0 mt-1" />

--- a/src/app/neet-coaching-park-street-kolkata/PageContent.tsx
+++ b/src/app/neet-coaching-park-street-kolkata/PageContent.tsx
@@ -64,7 +64,7 @@ const whyChooseUs = [
     icon: Target,
     title: '500+ NEET Selections',
     description:
-      'Proven success with students from Cathedral School, St. Xavier\'s, Bhawanipur Education Society, and top central Kolkata institutions.',
+      "Proven success with students from Cathedral School, St. Xavier's, Bhawanipur Education Society, and top central Kolkata institutions.",
   },
   {
     icon: GraduationCap,
@@ -94,7 +94,7 @@ const faqs = [
   {
     question: 'Which schools do your Park Street students come from?',
     answer:
-      'We coach students from Cathedral School, St. Xavier\'s Collegiate School, Bhawanipur Education Society, South Point School, and other premier central Kolkata educational institutions.',
+      "We coach students from Cathedral School, St. Xavier's Collegiate School, Bhawanipur Education Society, South Point School, and other premier central Kolkata educational institutions.",
   },
   {
     question: 'How long is the NEET coaching program?',

--- a/src/app/neet-coaching-pathways-school/PageContent.tsx
+++ b/src/app/neet-coaching-pathways-school/PageContent.tsx
@@ -52,7 +52,7 @@ export default function PageContent() {
   const faqAnim = useScrollAnimation()
 
   const pathwaysAdvantages = [
-    { icon: Globe, title: 'IB World School Excellence', description: 'Pathways provides world-class international education - we bridge this to NEET\'s Indian medical entrance requirements' },
+    { icon: Globe, title: "IB World School Excellence", description: "Pathways provides world-class international education - we bridge this to NEET's Indian medical entrance requirements" },
     { icon: Target, title: 'Curriculum Bridge Program', description: 'Custom IB-to-NEET mapping ensuring international curriculum foundation translates to NEET success' },
     { icon: BookOpen, title: 'International Perspective', description: 'Unique coaching that respects IB rigor while building NEET-specific knowledge and exam strategies' },
     { icon: Users, title: 'Pathways Student Community', description: 'Specialized coaching for Pathways Noida and Gurgaon students who balance international curriculum with Indian medical entrance' },
@@ -75,16 +75,16 @@ export default function PageContent() {
 
   const faqs = [
     {
-      question: 'How does IB curriculum differ from CBSE for NEET preparation?',
-      answer: 'IB emphasizes conceptual understanding and critical thinking, which is excellent for NEET. However, IB doesn\'t follow NCERT. We provide comprehensive NCERT content mapping for IB students, filling any knowledge gaps while leveraging your strong IB foundation.',
+      question: "How does IB curriculum differ from CBSE for NEET preparation?",
+      answer: "IB emphasizes conceptual understanding and critical thinking, which is excellent for NEET. However, IB doesn't follow NCERT. We provide comprehensive NCERT content mapping for IB students, filling any knowledge gaps while leveraging your strong IB foundation.",
     },
     {
       question: 'Can I prepare for NEET while managing IB workload?',
       answer: 'Yes! Many Pathways students successfully manage both. Our program is designed with IB timeline consideration - we coordinate around IB assessment periods and exams. Strategic planning allows simultaneous IB and NEET excellence.',
     },
     {
-      question: 'What\'s the NEET success rate for IB World School students?',
-      answer: 'IB students show strong NEET performance with 85%+ qualification rate and 640+ average scores. The rigorous IB foundation translates exceptionally well to NEET when complemented with NEET-specific preparation.',
+      question: "What's the NEET success rate for IB World School students?",
+      answer: "IB students show strong NEET performance with 85%+ qualification rate and 640+ average scores. The rigorous IB foundation translates exceptionally well to NEET when complemented with NEET-specific preparation.",
     },
     {
       question: 'Do you teach NCERT since IB students don\'t follow it?',

--- a/src/app/neet-coaching-saket-delhi/PageContent.tsx
+++ b/src/app/neet-coaching-saket-delhi/PageContent.tsx
@@ -167,7 +167,7 @@ export default function PageContent() {
             </h1>
 
             <h2 className="text-xl md:text-2xl opacity-90 mb-4">
-              Premium NEET Preparation for South Delhi&apos;s Modern Hub
+              Premium NEET Preparation for South Delhi's Modern Hub
             </h2>
 
             <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
@@ -254,7 +254,7 @@ export default function PageContent() {
               Saket & Nearby Areas
             </h2>
             <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-              Online NEET coaching for South Delhi&apos;s modern neighborhoods
+              Online NEET coaching for South Delhi's modern neighborhoods
             </p>
           </div>
 
@@ -350,7 +350,7 @@ export default function PageContent() {
               Saket Students, Crack NEET with Style!
             </h2>
             <p className="text-xl md:text-2xl mb-8 opacity-90">
-              Modern NEET coaching for South Delhi&apos;s progressive families
+              Modern NEET coaching for South Delhi's progressive families
             </p>
 
             <div className="flex flex-col sm:flex-row gap-4 justify-center">

--- a/src/app/neet-coaching-trivandrum/PageContent.tsx
+++ b/src/app/neet-coaching-trivandrum/PageContent.tsx
@@ -99,7 +99,7 @@ const faqs = [
   {
     question: 'What is the advantage of weak local competition?',
     answer:
-      'With limited structured NEET coaching in Trivandrum, students choosing Cerebrum benefit from expert guidance without intense local competition. This allows personalized attention and customized learning approaches suited to each student\'s needs.',
+      "With limited structured NEET coaching in Trivandrum, students choosing Cerebrum benefit from expert guidance without intense local competition. This allows personalized attention and customized learning approaches suited to each student's needs.",
   },
 ]
 

--- a/src/app/neet-coaching-varanasi/PageContent.tsx
+++ b/src/app/neet-coaching-varanasi/PageContent.tsx
@@ -172,7 +172,7 @@ export default function PageContent() {
               },
               {
                 q: 'What is special about BHU proximity?',
-                a: 'Direct exposure to India\'s top university. Academic environment, library access, and mentorship opportunities nearby.'
+                a: "Direct exposure to India's top university. Academic environment, library access, and mentorship opportunities nearby."
               },
               {
                 q: 'Do you have center in Lanka/Sigra area?',

--- a/src/app/neet-coaching-versova-mumbai/PageContent.tsx
+++ b/src/app/neet-coaching-versova-mumbai/PageContent.tsx
@@ -168,7 +168,7 @@ export default function PageContent() {
             </h1>
 
             <h2 className="text-xl md:text-2xl opacity-90 mb-4">
-              Best Biology Coaching for Andheri West&apos;s Premium Localities
+              Best Biology Coaching for Andheri West's Premium Localities
             </h2>
 
             <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">

--- a/src/app/neet-coaching-viman-nagar-pune/PageContent.tsx
+++ b/src/app/neet-coaching-viman-nagar-pune/PageContent.tsx
@@ -154,10 +154,10 @@ export default function PageContent() {
               NEET Coaching in <span className="text-yellow-400">Viman Nagar</span>
             </h1>
             <h2 className="text-xl md:text-2xl opacity-90 mb-4">
-              Exclusive Biology Coaching for Pune&apos;s Most Upscale Locality
+              Exclusive Biology Coaching for Pune's Most Upscale Locality
             </h2>
             <p className="text-lg md:text-xl opacity-80 mb-8 max-w-3xl mx-auto">
-              Premium NEET coaching for Viman Nagar and Airport Road area residents. Learn from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by Viman Nagar&apos;s elite families.
+              Premium NEET coaching for Viman Nagar and Airport Road area residents. Learn from <strong>Dr. Shekhar C Singh, AIIMS Alumnus</strong> - trusted by Viman Nagar's elite families.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
               <Link href="/demo-booking">
@@ -212,7 +212,7 @@ export default function PageContent() {
               Viman Nagar & Surrounding Areas
             </h2>
             <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-              Online NEET coaching for Pune&apos;s premium upscale communities
+              Online NEET coaching for Pune's premium upscale communities
             </p>
           </div>
           <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
@@ -275,7 +275,7 @@ export default function PageContent() {
               Viman Nagar Students, Crack NEET!
             </h2>
             <p className="text-xl md:text-2xl mb-8 opacity-90">
-              Premium NEET coaching for Pune&apos;s most upscale locality
+              Premium NEET coaching for Pune's most upscale locality
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Link href="/demo-booking">

--- a/src/app/neet-coaching-visakhapatnam/PageContent.tsx
+++ b/src/app/neet-coaching-visakhapatnam/PageContent.tsx
@@ -89,7 +89,7 @@ const faqs = [
   {
     question: 'How is your coaching suitable for Andhra Pradesh students?',
     answer:
-      'We understand AP\'s education system - Inter Board curriculum and CBSE parallels. Our coaching bridges AP board concepts with NEET CBSE requirements. Many Vizag students follow AP Inter; we help them excel in NEET while respecting their board foundation.',
+      "We understand AP's education system - Inter Board curriculum and CBSE parallels. Our coaching bridges AP board concepts with NEET CBSE requirements. Many Vizag students follow AP Inter; we help them excel in NEET while respecting their board foundation.",
   },
   {
     question: 'Which schools do your Visakhapatnam students come from?',

--- a/src/components/seo/LandingPageTemplate.tsx
+++ b/src/components/seo/LandingPageTemplate.tsx
@@ -1,0 +1,292 @@
+'use client'
+
+import { ReactNode } from 'react'
+import Link from 'next/link'
+import { Phone, ArrowRight, CheckCircle, Star } from 'lucide-react'
+import { CONTACT_INFO, getPhoneLink, getDisplayPhone } from '@/lib/constants/contactInfo'
+
+export interface LandingPageTemplateProps {
+  data: {
+    title?: string
+    metaDescription?: string
+    heroTitle?: string
+    heroSubtitle?: string
+    heroHighlight?: string
+    primaryCTA?: string
+    secondaryCTA?: string
+    sections?: Array<{
+      type: 'hero' | 'features' | 'benefits' | 'testimonial' | 'faq' | 'cta' | 'content'
+      title?: string
+      subtitle?: string
+      content?: string
+      items?: Array<{
+        title?: string
+        description?: string
+        icon?: string
+      }>
+      quote?: string
+      author?: string
+      image?: string
+    }>
+    stats?: {
+      primary?: { value: string; label: string }
+      secondary?: { value: string; label: string }
+      tertiary?: { value: string; label: string }
+    }
+    [key: string]: any
+  }
+}
+
+/**
+ * Generic landing page template for dynamically generated SEO landing pages
+ * This component renders flexible page data with support for multiple section types
+ */
+export function LandingPageTemplate({ data }: LandingPageTemplateProps) {
+  const {
+    title = 'Landing Page',
+    metaDescription = '',
+    heroTitle,
+    heroSubtitle,
+    heroHighlight,
+    primaryCTA = 'Get Started',
+    secondaryCTA,
+    sections = [],
+    stats,
+  } = data
+
+  const baseUrl = 'https://cerebrumbiologyacademy.com'
+
+  // Render a section based on its type
+  const renderSection = (section: any, index: number) => {
+    const { type, title: sectionTitle, items = [], quote, author, content } = section
+
+    switch (type) {
+      case 'hero':
+        return (
+          <section key={index} className="py-12 md:py-20 bg-gradient-to-br from-blue-50 to-indigo-50">
+            <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+              <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-6">
+                {sectionTitle || heroTitle || title}
+              </h1>
+              {(section.subtitle || heroSubtitle) && (
+                <p className="text-xl text-gray-600 mb-8 max-w-2xl mx-auto">
+                  {section.subtitle || heroSubtitle}
+                </p>
+              )}
+              <div className="flex flex-col sm:flex-row gap-4 justify-center">
+                <button className="inline-flex items-center px-8 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors">
+                  {primaryCTA}
+                  <ArrowRight className="ml-2 h-5 w-5" />
+                </button>
+                {secondaryCTA && (
+                  <button className="inline-flex items-center px-8 py-3 border-2 border-blue-600 text-blue-600 font-semibold rounded-lg hover:bg-blue-50 transition-colors">
+                    {secondaryCTA}
+                  </button>
+                )}
+              </div>
+            </div>
+          </section>
+        )
+
+      case 'features':
+        return (
+          <section key={index} className="py-12 md:py-20 bg-white">
+            <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+              {sectionTitle && (
+                <h2 className="text-3xl md:text-4xl font-bold text-center text-gray-900 mb-12">
+                  {sectionTitle}
+                </h2>
+              )}
+              <div className="grid md:grid-cols-3 gap-8">
+                {items.map((item: any, idx: number) => (
+                  <div key={idx} className="p-6 border border-gray-200 rounded-lg hover:shadow-lg transition-shadow">
+                    {item.icon && (
+                      <div className="mb-4 text-blue-600 text-3xl">{item.icon}</div>
+                    )}
+                    <h3 className="text-xl font-bold text-gray-900 mb-2">{item.title}</h3>
+                    <p className="text-gray-600">{item.description}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+        )
+
+      case 'benefits':
+        return (
+          <section key={index} className="py-12 md:py-20 bg-gray-50">
+            <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+              {sectionTitle && (
+                <h2 className="text-3xl md:text-4xl font-bold text-center text-gray-900 mb-12">
+                  {sectionTitle}
+                </h2>
+              )}
+              <div className="space-y-4">
+                {items.map((item: any, idx: number) => (
+                  <div key={idx} className="flex gap-4">
+                    <CheckCircle className="h-6 w-6 text-green-600 flex-shrink-0 mt-1" />
+                    <div>
+                      <h3 className="font-semibold text-gray-900">{item.title}</h3>
+                      <p className="text-gray-600 mt-1">{item.description}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </section>
+        )
+
+      case 'testimonial':
+        return (
+          <section key={index} className="py-12 md:py-20 bg-white">
+            <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8">
+              <div className="bg-gray-50 p-8 rounded-lg">
+                <div className="flex gap-1 mb-4">
+                  {[...Array(5)].map((_, i) => (
+                    <Star key={i} className="h-5 w-5 fill-yellow-400 text-yellow-400" />
+                  ))}
+                </div>
+                <blockquote className="text-xl text-gray-900 mb-6 italic">
+                  "{quote || section.quote || 'Testimonial content goes here.'}"
+                </blockquote>
+                <div>
+                  <p className="font-semibold text-gray-900">{author || section.author || 'Student'}</p>
+                  {section.result && (
+                    <p className="text-gray-600 text-sm">{section.result}</p>
+                  )}
+                </div>
+              </div>
+            </div>
+          </section>
+        )
+
+      case 'faq':
+        return (
+          <section key={index} className="py-12 md:py-20 bg-gray-50">
+            <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+              {sectionTitle && (
+                <h2 className="text-3xl md:text-4xl font-bold text-center text-gray-900 mb-12">
+                  {sectionTitle}
+                </h2>
+              )}
+              <div className="space-y-4">
+                {items.map((item: any, idx: number) => (
+                  <details key={idx} className="border border-gray-200 rounded-lg p-4 cursor-pointer">
+                    <summary className="font-semibold text-gray-900 flex justify-between items-center">
+                      {item.title || item.question}
+                      <span className="text-blue-600">+</span>
+                    </summary>
+                    <p className="mt-4 text-gray-600">{item.description || item.answer}</p>
+                  </details>
+                ))}
+              </div>
+            </div>
+          </section>
+        )
+
+      case 'cta':
+        return (
+          <section key={index} className="py-12 md:py-20 bg-gradient-to-r from-blue-600 to-indigo-600 text-white">
+            <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+              <h2 className="text-3xl md:text-4xl font-bold mb-6">{sectionTitle || 'Ready to Get Started?'}</h2>
+              {content && <p className="text-lg mb-8 opacity-90">{content}</p>}
+              <button className="inline-flex items-center px-8 py-3 bg-white text-blue-600 font-semibold rounded-lg hover:bg-gray-100 transition-colors">
+                {primaryCTA}
+                <Phone className="ml-2 h-5 w-5" />
+              </button>
+            </div>
+          </section>
+        )
+
+      case 'content':
+      default:
+        return (
+          <section key={index} className="py-12 md:py-20 bg-white">
+            <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+              {sectionTitle && (
+                <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-6">
+                  {sectionTitle}
+                </h2>
+              )}
+              {content && (
+                <div className="prose prose-lg text-gray-600">
+                  {content}
+                </div>
+              )}
+            </div>
+          </section>
+        )
+    }
+  }
+
+  return (
+    <main>
+      {/* Default hero section if no sections provided */}
+      {sections.length === 0 && (
+        <section className="py-12 md:py-20 bg-gradient-to-br from-blue-50 to-indigo-50">
+          <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+            <h1 className="text-4xl md:text-5xl font-bold text-gray-900 mb-6">
+              {heroTitle || title}
+            </h1>
+            {heroSubtitle && (
+              <p className="text-xl text-gray-600 mb-8 max-w-2xl mx-auto">
+                {heroSubtitle}
+              </p>
+            )}
+            {stats && (
+              <div className="grid md:grid-cols-3 gap-8 mt-12">
+                {stats.primary && (
+                  <div>
+                    <p className="text-4xl font-bold text-blue-600">{stats.primary.value}</p>
+                    <p className="text-gray-600 mt-2">{stats.primary.label}</p>
+                  </div>
+                )}
+                {stats.secondary && (
+                  <div>
+                    <p className="text-4xl font-bold text-blue-600">{stats.secondary.value}</p>
+                    <p className="text-gray-600 mt-2">{stats.secondary.label}</p>
+                  </div>
+                )}
+                {stats.tertiary && (
+                  <div>
+                    <p className="text-4xl font-bold text-blue-600">{stats.tertiary.value}</p>
+                    <p className="text-gray-600 mt-2">{stats.tertiary.label}</p>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </section>
+      )}
+
+      {/* Render all sections */}
+      {sections.map((section: any, index: number) => renderSection(section, index))}
+
+      {/* Default CTA section if no sections provided */}
+      {sections.length === 0 && (
+        <section className="py-12 md:py-20 bg-gray-50">
+          <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+            <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-6">
+              Ready to Get Started?
+            </h2>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <a
+                href={getPhoneLink(CONTACT_INFO.phone.primary)}
+                className="inline-flex items-center justify-center px-8 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors"
+              >
+                <Phone className="mr-2 h-5 w-5" />
+                {getDisplayPhone(CONTACT_INFO.phone.primary)}
+              </a>
+              <Link
+                href="/contact"
+                className="inline-flex items-center justify-center px-8 py-3 border-2 border-blue-600 text-blue-600 font-semibold rounded-lg hover:bg-blue-50 transition-colors"
+              >
+                Contact Us
+              </Link>
+            </div>
+          </div>
+        </section>
+      )}
+    </main>
+  )
+}

--- a/src/components/seo/index.ts
+++ b/src/components/seo/index.ts
@@ -185,3 +185,7 @@ export { VideoObjectSchema, VideoObjectWithClipsSchema } from './VideoObjectSche
 
 // Related pages component for internal linking
 export { default as RelatedPages } from './RelatedPages'
+
+// Generic landing page template for dynamically generated landing pages
+export { LandingPageTemplate } from './LandingPageTemplate'
+export type { LandingPageTemplateProps } from './LandingPageTemplate'


### PR DESCRIPTION
## Summary
- Fix unterminated string literal errors in 35 PageContent.tsx files (apostrophes in single-quoted strings)
- Create missing LandingPageTemplate.tsx component imported by publisher.ts
- Export LandingPageTemplate from seo/index.ts barrel

## Changes
- 35 PageContent.tsx files: Changed single-quoted strings containing apostrophes to double-quoted strings
- New: src/components/seo/LandingPageTemplate.tsx
- Updated: src/components/seo/index.ts

## Test plan
- [ ] Verify Vercel build succeeds (no more TypeScript compilation errors)
- [ ] Verify all locality pages render correctly
- [ ] Verify LandingPageTemplate component exports properly