### PR TITLE
Fix duplicate lucide-react imports causing build failure

### DIFF
--- a/src/app/neet-coaching-kondapur-hyderabad/PageContent.tsx
+++ b/src/app/neet-coaching-kondapur-hyderabad/PageContent.tsx
@@ -12,7 +12,6 @@ import {
   GraduationCap,
   Target,
   Building,
-  Building,
 } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import Link from 'next/link'

--- a/src/app/neet-coaching-nungambakkam-chennai/PageContent.tsx
+++ b/src/app/neet-coaching-nungambakkam-chennai/PageContent.tsx
@@ -12,7 +12,6 @@ import {
   GraduationCap,
   Target,
   Building,
-  Building,
 } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import Link from 'next/link'

--- a/src/app/neet-coaching-velachery-chennai/PageContent.tsx
+++ b/src/app/neet-coaching-velachery-chennai/PageContent.tsx
@@ -12,7 +12,6 @@ import {
   GraduationCap,
   Target,
   Building,
-  MapPin,
 } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
 import Link from 'next/link'


### PR DESCRIPTION
## Summary
Remove duplicate icon imports in 3 PageContent.tsx files that cause Next.js compilation to fail with "Identifier has already been declared" errors.

## Files Fixed
- kondapur-hyderabad: Building imported twice
- velachery-chennai: MapPin imported twice
- nungambakkam-chennai: Building imported twice