### PR TITLE
Fix duplicate lucide-react imports in 4 component files

### DIFF
--- a/src/components/layout/SophisticatedHero.tsx
+++ b/src/components/layout/SophisticatedHero.tsx
@@ -18,9 +18,9 @@ import {
   FlaskConical,
   BarChart2,
   Globe,
+  Star,
 } from 'lucide-react'
 import { getPlaceholderAvatar } from '@/lib/images/imageUtils'
-import { Star } from 'lucide-react'
 
 interface SophisticatedHeroProps {
   onDemoBooking?: () => void

--- a/src/components/resources/ChapterNotesViewer.tsx
+++ b/src/components/resources/ChapterNotesViewer.tsx
@@ -11,7 +11,8 @@ import {
   Clock,
   Download,
 } from 'lucide-react'
-import { Bookmark as BookmarkSolidIcon } from 'lucide-react'
+
+const BookmarkSolidIcon = Bookmark
 
 interface ChapterNote {
   id: string

--- a/src/components/resources/QuestionBankBrowser.tsx
+++ b/src/components/resources/QuestionBankBrowser.tsx
@@ -12,7 +12,8 @@ import {
   Eye,
   FlaskConical,
 } from 'lucide-react'
-import { Bookmark as BookmarkSolidIcon } from 'lucide-react'
+
+const BookmarkSolidIcon = Bookmark
 
 interface Question {
   id: string

--- a/src/components/student/AssignmentList.tsx
+++ b/src/components/student/AssignmentList.tsx
@@ -3,11 +3,10 @@
 import React, { useState } from 'react'
 import { AssignmentCard } from './AssignmentCard'
 import { Assignment, SubmissionStatus } from '@/types/assignment'
-import { Search } from 'lucide-react'
+import { Search, FileText } from 'lucide-react'
 import { Input } from '@/components/ui/Input'
 import { NativeSelect } from '@/components/ui/NativeSelect'
 import { EmptyState } from '@/components/ui/EmptyState'
-import { FileText } from 'lucide-react'
 
 interface AssignmentListProps {
   assignments: Array<


### PR DESCRIPTION
Consolidate duplicate lucide-react import statements in 4 files:
- SophisticatedHero.tsx: merge Star into main import block
- ChapterNotesViewer.tsx: use const alias instead of duplicate import
- QuestionBankBrowser.tsx: use const alias instead of duplicate import
- AssignmentList.tsx: merge FileText into main import

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>