### PR TITLE
fix: change 36 Button default imports to named imports

### DIFF
--- a/src/app/boards/gujarat-hsc/PageContent.tsx
+++ b/src/app/boards/gujarat-hsc/PageContent.tsx
@@ -14,7 +14,7 @@ import {
   FileText,
   Microscope,
 } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/boards/maharashtra-hsc/PageContent.tsx
+++ b/src/app/boards/maharashtra-hsc/PageContent.tsx
@@ -14,7 +14,7 @@ import {
   FileText,
   Microscope,
 } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/boards/tamil-nadu-hsc/PageContent.tsx
+++ b/src/app/boards/tamil-nadu-hsc/PageContent.tsx
@@ -14,7 +14,7 @@ import {
   FileText,
   Microscope,
 } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/boards/telangana-intermediate/PageContent.tsx
+++ b/src/app/boards/telangana-intermediate/PageContent.tsx
@@ -14,7 +14,7 @@ import {
   FileText,
   Microscope,
 } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/boards/up-intermediate/PageContent.tsx
+++ b/src/app/boards/up-intermediate/PageContent.tsx
@@ -14,7 +14,7 @@ import {
   FileText,
   Microscope,
 } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/boards/west-bengal-hs/PageContent.tsx
+++ b/src/app/boards/west-bengal-hs/PageContent.tsx
@@ -14,7 +14,7 @@ import {
   FileText,
   Microscope,
 } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-agra/PageContent.tsx
+++ b/src/app/neet-coaching-agra/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield, ArrowRight, BookOpen, CheckCircle } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-cairo-egypt/PageContent.tsx
+++ b/src/app/neet-coaching-cairo-egypt/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield, ArrowRight, BookOpen, CheckCircle, Globe, Clock } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-cathedral-school-mumbai/PageContent.tsx
+++ b/src/app/neet-coaching-cathedral-school-mumbai/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Star, GraduationCap, Target, Shield, ArrowRight, BookOpen, CheckCircle, Building, MapPin } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-chirec-hyderabad/PageContent.tsx
+++ b/src/app/neet-coaching-chirec-hyderabad/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Star, GraduationCap, Target, Shield, ArrowRight, BookOpen, CheckCircle, Building, MapPin } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-colombo-sri-lanka/PageContent.tsx
+++ b/src/app/neet-coaching-colombo-sri-lanka/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield, ArrowRight, BookOpen, CheckCircle, Globe, Clock } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-dhaka-bangladesh/PageContent.tsx
+++ b/src/app/neet-coaching-dhaka-bangladesh/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield, ArrowRight, BookOpen, CheckCircle, Globe, Clock } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-doha-qatar/PageContent.tsx
+++ b/src/app/neet-coaching-doha-qatar/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield, ArrowRight, BookOpen, CheckCircle, Globe, Clock } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-dps-bangalore/PageContent.tsx
+++ b/src/app/neet-coaching-dps-bangalore/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Star, GraduationCap, Target, Shield, ArrowRight, BookOpen, CheckCircle, Building, MapPin } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-dps-chandigarh/PageContent.tsx
+++ b/src/app/neet-coaching-dps-chandigarh/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Star, GraduationCap, Target, Shield, ArrowRight, BookOpen, CheckCircle, Building, MapPin } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-guwahati/PageContent.tsx
+++ b/src/app/neet-coaching-guwahati/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield, ArrowRight, BookOpen, CheckCircle } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-heritage-xperiential/PageContent.tsx
+++ b/src/app/neet-coaching-heritage-xperiential/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Star, GraduationCap, Target, Shield, ArrowRight, BookOpen, CheckCircle, Building, MapPin } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-jeddah-saudi-arabia/PageContent.tsx
+++ b/src/app/neet-coaching-jeddah-saudi-arabia/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield, ArrowRight, BookOpen, CheckCircle, Globe, Clock } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-lahore-pakistan/PageContent.tsx
+++ b/src/app/neet-coaching-lahore-pakistan/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield, ArrowRight, BookOpen, CheckCircle, Globe, Clock } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-mallya-aditi-bangalore/PageContent.tsx
+++ b/src/app/neet-coaching-mallya-aditi-bangalore/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Star, GraduationCap, Target, Shield, ArrowRight, BookOpen, CheckCircle, Building, MapPin } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-mangalore/PageContent.tsx
+++ b/src/app/neet-coaching-mangalore/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield, ArrowRight, BookOpen, CheckCircle } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-muscat-oman/PageContent.tsx
+++ b/src/app/neet-coaching-muscat-oman/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield, ArrowRight, BookOpen, CheckCircle, Globe, Clock } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-mysore/PageContent.tsx
+++ b/src/app/neet-coaching-mysore/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield, ArrowRight, BookOpen, CheckCircle } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-nagpur/PageContent.tsx
+++ b/src/app/neet-coaching-nagpur/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield, ArrowRight, BookOpen, CheckCircle } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-oakridge-hyderabad/PageContent.tsx
+++ b/src/app/neet-coaching-oakridge-hyderabad/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Star, GraduationCap, Target, Shield, ArrowRight, BookOpen, CheckCircle, Building, MapPin } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-patna/PageContent.tsx
+++ b/src/app/neet-coaching-patna/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield, ArrowRight, BookOpen, CheckCircle } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-raipur/PageContent.tsx
+++ b/src/app/neet-coaching-raipur/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield, ArrowRight, BookOpen, CheckCircle } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-ranchi/PageContent.tsx
+++ b/src/app/neet-coaching-ranchi/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield, ArrowRight, BookOpen, CheckCircle } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-riyadh-saudi-arabia/PageContent.tsx
+++ b/src/app/neet-coaching-riyadh-saudi-arabia/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield, ArrowRight, BookOpen, CheckCircle, Globe, Clock } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-sanskriti-school/PageContent.tsx
+++ b/src/app/neet-coaching-sanskriti-school/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Star, GraduationCap, Target, Shield, ArrowRight, BookOpen, CheckCircle, Building, MapPin } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-siliguri/PageContent.tsx
+++ b/src/app/neet-coaching-siliguri/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield, ArrowRight, BookOpen, CheckCircle } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-st-columbas-school/PageContent.tsx
+++ b/src/app/neet-coaching-st-columbas-school/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Star, GraduationCap, Target, Shield, ArrowRight, BookOpen, CheckCircle, Building, MapPin } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-surat/PageContent.tsx
+++ b/src/app/neet-coaching-surat/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield, ArrowRight, BookOpen, CheckCircle } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-thiruvananthapuram/PageContent.tsx
+++ b/src/app/neet-coaching-thiruvananthapuram/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield, ArrowRight, BookOpen, CheckCircle } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-varanasi/PageContent.tsx
+++ b/src/app/neet-coaching-varanasi/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Play, Headphones, MapPin, Star, GraduationCap, Target, Building, Shield, ArrowRight, BookOpen, CheckCircle } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)

--- a/src/app/neet-coaching-vasant-valley-school/PageContent.tsx
+++ b/src/app/neet-coaching-vasant-valley-school/PageContent.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useEffect, useRef, useState } from 'react'
 import { Trophy, Users, MessageCircle, Star, GraduationCap, Target, Shield, ArrowRight, BookOpen, CheckCircle, Building, MapPin } from 'lucide-react'
-import Button from '@/components/ui/Button'
+import { Button } from '@/components/ui/Button'
 
 function useScrollAnimation() {
   const ref = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
## Problem

36 PageContent.tsx files used `import Button from @/components/ui/Button` (default import) but Button.tsx only has named exports: `export { Button, buttonVariants }`.

This caused:
- "Attempted import error" warnings filling the Vercel build log (~180 warning events)
- Button resolving to `undefined` during static page generation
- **Build failure on Vercel** even though webpack compilation succeeded

## Fix

Changed all 36 files from:
```tsx
import Button from @/components/ui/Button
```
to:
```tsx
import { Button } from @/components/ui/Button
```

## Files Changed
- 6 board pages (gujarat-hsc, maharashtra-hsc, tamil-nadu-hsc, telangana-intermediate, up-intermediate, west-bengal-hs)
- 16 city coaching pages
- 8 school coaching pages
- 6 international coaching pages

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>